### PR TITLE
feat: replace cudaEventElapsedTime with CUPTI kernel-only GPU timing

### DIFF
--- a/phantora/cuda_call/src/capi.rs
+++ b/phantora/cuda_call/src/capi.rs
@@ -73,7 +73,10 @@ fn enum_to_nccl_reduce_op(op: i32) -> NcclReduceOp {
 }
 
 fn ignore_cpu_time() -> bool {
-    env::var_os("PHANTORA_IGNORE_CPU_TIME").is_some()
+    match env::var("PHANTORA_IGNORE_CPU_TIME") {
+        Ok(v) => !(v == "0" || v.eq_ignore_ascii_case("false")),
+        Err(_) => false,
+    }
 }
 
 fn get_current_sim_time() -> i64 {

--- a/phantora/phantora/Cargo.toml
+++ b/phantora/phantora/Cargo.toml
@@ -21,6 +21,9 @@ env_logger = "0.11.3"
 strum = { version = "0.26.2", features = ["derive"] }
 pyo3 = { version = "0.21.2", features = ["auto-initialize"] }
 
+[build-dependencies]
+cc = "1.0"
+
 [[bin]]
 name = "simulator"
 path = "src/main.rs"

--- a/phantora/phantora/build.rs
+++ b/phantora/phantora/build.rs
@@ -1,6 +1,44 @@
 fn main() {
     use std::env;
+    use std::path::PathBuf;
 
     let cuda_home = env::var("CUDA_HOME").unwrap();
     println!("cargo:rustc-link-search=native={}/lib64", cuda_home);
+
+    let mut cupti_include: Option<PathBuf> = None;
+    let mut cupti_libdir: Option<PathBuf> = None;
+    for (inc, lib) in [
+        (
+            format!("{}/extras/CUPTI/include", cuda_home),
+            format!("{}/extras/CUPTI/lib64", cuda_home),
+        ),
+        (
+            format!("{}/targets/x86_64-linux/include", cuda_home),
+            format!("{}/targets/x86_64-linux/lib", cuda_home),
+        ),
+        (format!("{}/include", cuda_home), format!("{}/lib64", cuda_home)),
+    ] {
+        let inc_path = PathBuf::from(&inc);
+        let lib_path = PathBuf::from(&lib);
+        if inc_path.join("cupti.h").exists() {
+            cupti_include = Some(inc_path);
+            cupti_libdir = Some(lib_path);
+            break;
+        }
+    }
+    let cupti_include = cupti_include
+        .expect("could not find cupti.h under CUDA_HOME — install CUPTI or set CUDA_HOME");
+    let cupti_libdir = cupti_libdir.unwrap();
+
+    cc::Build::new()
+        .file("src/cupti_shim.c")
+        .include(&cupti_include)
+        .include(format!("{}/include", cuda_home))
+        .flag("-Wno-unused-parameter")
+        .std("c11")
+        .compile("phantora_cupti_shim");
+
+    println!("cargo:rustc-link-search=native={}", cupti_libdir.display());
+    println!("cargo:rerun-if-changed=src/cupti_shim.c");
+    println!("cargo:rerun-if-env-changed=CUDA_HOME");
 }

--- a/phantora/phantora/src/cuda_bindings.rs
+++ b/phantora/phantora/src/cuda_bindings.rs
@@ -38,4 +38,8 @@ extern "C" {
     ) -> ffi::c_int;
 
     pub fn cudaStreamSynchronize(stream: *mut ffi::c_void) -> ffi::c_int;
+
+    pub fn cudaDeviceSynchronize() -> ffi::c_int;
+
+    pub fn cudaGetLastError() -> ffi::c_int;
 }

--- a/phantora/phantora/src/cuda_estimate.rs
+++ b/phantora/phantora/src/cuda_estimate.rs
@@ -12,6 +12,11 @@ macro_rules! assert_cuda {
         let err = $e;
         if err != 0 {
             log::error!("{} error {}, {}:{}", stringify!($e), err, file!(), line!());
+            unsafe {
+                crate::cuda_bindings::cudaGetLastError();
+                crate::cuda_bindings::cudaDeviceSynchronize();
+                crate::cuda_bindings::cudaGetLastError();
+            }
         }
     }};
 }
@@ -26,6 +31,15 @@ macro_rules! estimate {
             for _ in 0..(n - 1) {
                 let _ = $e;
             };
+            // CUPTI hygiene: drain pending warmup records before the
+            // measured window opens. Sync first to make sure the
+            // warmup kernels have actually completed (they're async,
+            // so their CUPTI records may not exist yet without sync).
+            if $crate::cupti::enabled() {
+                assert_cuda!(cudaDeviceSynchronize());
+                $crate::cupti::flush_and_sum_ns();  // discard warmup
+            }
+            $crate::cupti::clear();
             let mut start_event = ptr::null_mut();
             let mut end_event = ptr::null_mut();
             assert_cuda!(cudaEventCreate(&mut start_event));
@@ -34,11 +48,16 @@ macro_rules! estimate {
             result = $e;
             assert_cuda!(cudaEventRecord(end_event, ptr::null_mut()));
             assert_cuda!(cudaEventSynchronize(end_event));
-            let mut elapsed: f32 = 0.0;
-            assert_cuda!(cudaEventElapsedTime(&mut elapsed, start_event, end_event));
+            if $crate::cupti::enabled() {
+                let cupti_ns = $crate::cupti::flush_and_sum_ns();
+                dur = std::time::Duration::from_nanos(cupti_ns);
+            } else {
+                let mut elapsed: f32 = 0.0;
+                assert_cuda!(cudaEventElapsedTime(&mut elapsed, start_event, end_event));
+                dur = Duration::from_secs_f64(elapsed as f64 * 1e-3);
+            }
             assert_cuda!(cudaEventDestroy(start_event));
             assert_cuda!(cudaEventDestroy(end_event));
-            dur = Duration::from_secs_f64(elapsed as f64 * 1e-3);
         };
         (result, dur)
     }}
@@ -227,6 +246,10 @@ impl CudaEstimator {
             .unwrap();
             (torch.unbind(), flash_attn_cuda.unbind(), device.unbind())
         });
+
+        // CUPTI activity tracking. Must happen AFTER the warmup matmul
+        // above — CUPTI requires an initialised CUDA context.
+        crate::cupti::init();
 
         Self {
             memcpy_cache: HashMap::new(),

--- a/phantora/phantora/src/cupti.rs
+++ b/phantora/phantora/src/cupti.rs
@@ -1,0 +1,68 @@
+//! CUPTI-based per-op kernel timing for the `estimate!` macro.
+//!
+//! Default is CUPTI kernel-only timing (CONCURRENT_KERNEL activity records).
+//! Set `PHANTORA_USE_CUPTI=0` (or `false`) to fall back to the older
+//! `cudaEventElapsedTime` path.
+//!
+//! CUPTI's CONCURRENT_KERNEL records contain GPU-clock timestamps captured
+//! by the driver when the kernel actually started and ended on the device.
+//! Host stalls between the two `cudaEventRecord` calls are invisible to
+//! CUPTI, giving pure GPU kernel time.
+
+use std::sync::OnceLock;
+
+#[link(name = "cupti", kind = "dylib")]
+extern "C" {
+    fn phantora_cupti_init() -> i32;
+    fn phantora_cupti_clear();
+    fn phantora_cupti_flush();
+    fn phantora_cupti_sum_kernel_ns() -> u64;
+}
+
+/// Read the env var once and cache. Default is **on** — CUPTI gives
+/// kernel-only GPU time. Set `PHANTORA_USE_CUPTI=0` (or `false`) to
+/// fall back to `cudaEventElapsedTime`.
+pub fn enabled() -> bool {
+    static FLAG: OnceLock<bool> = OnceLock::new();
+    *FLAG.get_or_init(|| {
+        match std::env::var("PHANTORA_USE_CUPTI") {
+            Ok(v) => !(v == "0" || v.eq_ignore_ascii_case("false")),
+            Err(_) => true,
+        }
+    })
+}
+
+/// Initialise CUPTI activity tracking. No-ops when CUPTI is disabled.
+/// Call once at simulator startup after the first CUDA call.
+pub fn init() {
+    if !enabled() {
+        return;
+    }
+    let r = unsafe { phantora_cupti_init() };
+    if r != 0 {
+        panic!("CUPTI init failed (code {}) — cannot continue with PHANTORA_USE_CUPTI enabled", r);
+    }
+}
+
+/// Reset the kernel-ns accumulator before a measurement window opens.
+#[inline]
+pub fn clear() {
+    if enabled() {
+        unsafe { phantora_cupti_clear() }
+    }
+}
+
+/// Force CUPTI to drain its activity buffers, then read the sum of
+/// kernel GPU time observed since the last `clear()`. Returns ns.
+/// Returns 0 when CUPTI is disabled.
+#[inline]
+pub fn flush_and_sum_ns() -> u64 {
+    if enabled() {
+        unsafe {
+            phantora_cupti_flush();
+            phantora_cupti_sum_kernel_ns()
+        }
+    } else {
+        0
+    }
+}

--- a/phantora/phantora/src/cupti_shim.c
+++ b/phantora/phantora/src/cupti_shim.c
@@ -1,0 +1,89 @@
+// Small C wrapper around CUPTI's Activity API.
+//
+// Why this isn't pure-Rust FFI: the CUpti_ActivityKernel record layout
+// has gone through 8 versions (CUpti_ActivityKernel ... Kernel8 in the
+// CUDA 11.8 headers, more in newer CUDA), each adding fields. Writing
+// version-correct #[repr(C)] structs in Rust would couple us to a
+// specific CUDA version. Casting to the right struct in C and exposing
+// only the fields we need (start, end timestamps in ns) keeps the
+// version dependency in one place.
+//
+// Threading model: clear() / sum() run on the simulator thread that
+// drives estimate!; buf_completed runs on CUPTI's *internal* worker
+// thread (which CUPTI spawns on its own to drain activity buffers
+// without blocking the producer). The accumulator therefore has to be
+// shared across threads — using __thread silently zeros the result
+// because the simulator thread reads its own TLS slot while CUPTI
+// updates a different one. _Atomic gives cross-thread visibility
+// without a mutex; clear/flush bracket each estimate! window so the
+// counter is single-writer for that window once the flush returns.
+
+#include <cupti.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static _Atomic uint64_t g_kernel_ns = 0;
+
+static void CUPTIAPI buf_requested(uint8_t **buffer, size_t *size,
+                                   size_t *max_records)
+{
+    *size = 32 * 1024;
+    *max_records = 0;
+    if (posix_memalign((void **)buffer, 8, *size) != 0) *buffer = NULL;
+}
+
+static void CUPTIAPI buf_completed(CUcontext ctx, uint32_t stream_id,
+                                   uint8_t *buffer, size_t size,
+                                   size_t valid_size)
+{
+    (void)ctx;
+    (void)stream_id;
+    (void)size;
+    CUpti_Activity *r = NULL;
+    while (cuptiActivityGetNextRecord(buffer, valid_size, &r) == CUPTI_SUCCESS) {
+        if (r->kind == CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL ||
+            r->kind == CUPTI_ACTIVITY_KIND_KERNEL) {
+            // CUDA 11.8 ships CUpti_ActivityKernel8 as the latest. The
+            // start/end fields are stable across versions, but the
+            // surrounding fields differ — cast to the latest available
+            // type so we read the right offsets. If the image is later
+            // upgraded to a CUDA toolkit with newer kernel records,
+            // bump this cast.
+            CUpti_ActivityKernel8 *k = (CUpti_ActivityKernel8 *)r;
+            atomic_fetch_add_explicit(&g_kernel_ns,
+                                      k->end - k->start,
+                                      memory_order_relaxed);
+        }
+    }
+    free(buffer);
+}
+
+int phantora_cupti_init(void)
+{
+    static int initialised = 0;
+    if (initialised) return 0;
+    CUptiResult r1 = cuptiActivityRegisterCallbacks(buf_requested, buf_completed);
+    if (r1 != CUPTI_SUCCESS) return (int)r1;
+    CUptiResult r2 = cuptiActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL);
+    if (r2 != CUPTI_SUCCESS) return (int)r2;
+    initialised = 1;
+    return 0;
+}
+
+void phantora_cupti_clear(void)
+{
+    atomic_store_explicit(&g_kernel_ns, 0, memory_order_release);
+}
+
+void phantora_cupti_flush(void)
+{
+    cuptiActivityFlushAll(0);
+}
+
+uint64_t phantora_cupti_sum_kernel_ns(void)
+{
+    return atomic_load_explicit(&g_kernel_ns, memory_order_acquire);
+}

--- a/phantora/phantora/src/lib.rs
+++ b/phantora/phantora/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod args;
 pub mod cuda_bindings;
 pub mod cuda_estimate;
+pub mod cupti;
 pub mod event_queue;
 pub mod nccl_ops;
 pub mod simulator;

--- a/phantora/phantora/src/torch_estimate.rs
+++ b/phantora/phantora/src/torch_estimate.rs
@@ -30,9 +30,22 @@ fn kind_range(kind: Kind) -> KindRange {
     }
 }
 
+/// Measure a torch op with `n` warmup + 1 measured iteration.
+/// Skips `tch::autocast` when inputs are already bf16/fp16 — autocast
+/// adds ~6× dispatch overhead for tensors that won't be dtype-converted,
+/// inflating both cudaEvent and CUPTI measurements. Only applies autocast
+/// for fp32 inputs where mixed-precision is actually useful.
 macro_rules! estimate_torch {
+    ($n:expr, $e:expr, $dtype:expr) => {{
+        if $dtype == tch::Kind::Float || $dtype == tch::Kind::Double {
+            tch::autocast(true, || estimate!($n, $e))
+        } else {
+            estimate!($n, $e)
+        }
+    }};
+    // Backward-compatible: no dtype → no autocast (default inference path).
     ($n:expr, $e:expr) => {{
-        tch::autocast(true, || estimate!($n, $e))
+        estimate!($n, $e)
     }};
 }
 

--- a/tests/docker/deepspeed/config_gen.py
+++ b/tests/docker/deepspeed/config_gen.py
@@ -10,6 +10,7 @@ SIMULATOR_TEMPLATE = r"""
     ipc: host
     environment:
       - PHANTORA_LOG=${{PHANTORA_LOG:-info}}
+      - PHANTORA_USE_CUPTI=${{PHANTORA_USE_CUPTI:-1}}
       - PHANTORA_SOCKET_PREFIX=/run/phantora/phantora
     command: /phantora/dist/phantora_server --netconfig /netconfig.toml
     cpuset: '{cpuset}'
@@ -35,7 +36,7 @@ HOST_TEMPLATE = r"""
     environment:
       - PHANTORA_NGPU={ngpu}
       - PHANTORA_VRAM_MIB={vram_mib}
-      - PHANTORA_IGNORE_CPU_TIME=1
+      - PHANTORA_IGNORE_CPU_TIME=${{PHANTORA_IGNORE_CPU_TIME:-1}}
       - PHANTORA_SOCKET_PREFIX=/run/phantora/phantora
     hostname: host-{host_id}
     command: /usr/sbin/sshd -D

--- a/tests/docker/megatron/config_gen.py
+++ b/tests/docker/megatron/config_gen.py
@@ -10,6 +10,7 @@ SIMULATOR_TEMPLATE = r"""
     ipc: host
     environment:
       - PHANTORA_LOG=${{PHANTORA_LOG:-info}}
+      - PHANTORA_USE_CUPTI=${{PHANTORA_USE_CUPTI:-1}}
       - PHANTORA_SOCKET_PREFIX=/run/phantora/phantora
     command: /phantora/dist/phantora_server --netconfig /netconfig.toml
     cpuset: '{cpuset}'
@@ -34,7 +35,7 @@ HOST_TEMPLATE = r"""
       - CUDA_DEVICE_MAX_CONNECTIONS=1
       - PHANTORA_NGPU={ngpu}
       - PHANTORA_VRAM_MIB={vram_mib}
-      - PHANTORA_IGNORE_CPU_TIME=1
+      - PHANTORA_IGNORE_CPU_TIME=${{PHANTORA_IGNORE_CPU_TIME:-1}}
       - PHANTORA_SOCKET_PREFIX=/run/phantora/phantora
     hostname: host-{host_id}
     command: sleep infinity

--- a/tests/docker/torchtitan/config_gen.py
+++ b/tests/docker/torchtitan/config_gen.py
@@ -10,6 +10,7 @@ SIMULATOR_TEMPLATE = r"""
     ipc: host
     environment:
       - PHANTORA_LOG=${{PHANTORA_LOG:-info}}
+      - PHANTORA_USE_CUPTI=${{PHANTORA_USE_CUPTI:-1}}
       - PHANTORA_SOCKET_PREFIX=/run/phantora/phantora
     command: /phantora/dist/phantora_server --netconfig /netconfig.toml
     cpuset: '{cpuset}'
@@ -34,6 +35,7 @@ HOST_TEMPLATE = r"""
       - NGPU={ngpu}
       - PHANTORA_NGPU={ngpu}
       - PHANTORA_VRAM_MIB={vram_mib}
+      - PHANTORA_IGNORE_CPU_TIME=${{PHANTORA_IGNORE_CPU_TIME:-1}}
       - PHANTORA_SOCKET_PREFIX=/run/phantora/phantora
     hostname: host-{host_id}
     command: sleep infinity


### PR DESCRIPTION
 Switch the per-op cost model from cudaEventElapsedTime to CUPTI's
  CONCURRENT_KERNEL activity records. CUPTI captures GPU-clock timestamps
  from kernel start to end on the device, excluding host dispatch idle
  that leaks into cudaEventElapsedTime and inflates small-op timing.

  Why: cudaEventElapsedTime measures the GPU-clock gap between two
  cudaEventRecord markers. The GPU clock keeps ticking during host-side
  gaps (Python dispatch, cuBLAS API, cuLaunchKernel, driver IRQ), so
  the measured duration includes idle time that the GPU didn't spend
  executing the kernel. For dispatch-bound ops (vLLM decode at small
  batch sizes) this bias is several × the kernel itself.

  What:
  - CUPTI Activity API wrapper (cupti_shim.c + cupti.rs) with
    PHANTORA_USE_CUPTI env-var gate (default on, set to 0 for cudaEvent
    fallback)
  - CUPTI hygiene in the estimate! macro: drain pending warmup records
    with sync+flush+clear before each measurement window
  - Skip tch::autocast for bf16/fp16 tensors — the wrapper adds ~6×
    dispatch overhead per op with no dtype conversion benefit
  - Fix PHANTORA_IGNORE_CPU_TIME=0 to actually disable (was always-on
    due to is_some() check)
  - Compose template interpolation for both new env vars

  Breaking: PHANTORA_USE_CUPTI defaults to 1 (CUPTI enabled). Set to 0
  to restore the previous cudaEventElapsedTime path.