### PR TITLE
NCCL P2P simulation + CUPTI activity timing + torch op support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Phantora ships a stub `libnccl.so` that intercepts NCCL calls and forwards them 
 | `ncclBcast` (legacy in-place API) | ✅ Supported |
 | `ncclBroadcast` | ❌ Not implemented |
 | `ncclReduce` | ❌ Not implemented |
-| `ncclSend` (point-to-point) | 🚧 Work in progress |
-| `ncclRecv` (point-to-point) | 🚧 Work in progress |
+| `ncclSend` (point-to-point) | ✅ Supported |
+| `ncclRecv` (point-to-point) | ✅ Supported |
 
-`ncclSend` / `ncclRecv` are actively being worked on — once they land, pipeline parallelism and (via grouped point-to-point) expert parallelism / all-to-all will become simulatable across all three frameworks.
+`ncclSend` / `ncclRecv` are simulated for timing and stream ordering, including calls batched by `ncclGroupStart` / `ncclGroupEnd`. Phantora does not copy tensor payloads between ranks; receive buffers contain whatever simulated CUDA memory already holds. Framework paths that inspect data sent over NCCL, including shape or dtype metadata encoded in tensors, may still fail or diverge.
 
 **Communicator, group, and utility calls**
 
@@ -66,7 +66,7 @@ The full set of stubs lives in [`stub/nccl.c`](stub/nccl.c). Pull requests to ex
 
 ### Framework feature support
 
-The matrix below summarises which features of each supported framework Phantora can simulate today. A 🚧 row maps to a missing underlying collective in the NCCL table above, or to a separate communication library that Phantora does not yet intercept.
+The matrix below summarises which features of each supported framework Phantora can simulate today. A 🚧 row maps to an unsupported API, missing communication semantics, or a separate communication library that Phantora does not yet intercept.
 
 | Feature | Megatron | DeepSpeed | TorchTitan | Required collective(s) |
 | --- | :---: | :---: | :---: | --- |
@@ -75,12 +75,12 @@ The matrix below summarises which features of each supported framework Phantora 
 | ZeRO-1 / ZeRO-2 / ZeRO-3 | — | ✅ | — | AllReduce, AllGather, ReduceScatter |
 | FSDP / FSDP2 | — | — | ✅ | AllGather, ReduceScatter |
 | Activation checkpointing | ✅ | ✅ | ✅ | (no extra communication) |
-| Pipeline parallelism (PP) | 🚧 | 🚧 | 🚧 | `ncclSend` / `ncclRecv` (point-to-point) — in progress |
-| Expert parallelism / MoE | 🚧 | 🚧 | 🚧 | All-to-all via `ncclSend` / `ncclRecv` groups (in progress), and/or [DeepEP](https://github.com/deepseek-ai/DeepEP) |
+| Pipeline parallelism (PP) | ✅ | 🚧 | 🚧 | `ncclSend` / `ncclRecv`; DeepSpeed and TorchTitan also need data-carrying metadata exchange |
+| Expert parallelism / MoE | 🚧 | 🚧 | 🚧 | All-to-all via grouped `ncclSend` / `ncclRecv`, payload/routing semantics, and/or [DeepEP](https://github.com/deepseek-ai/DeepEP) |
 
-Two communication paths gate the 🚧 rows, and we are actively closing both:
+Two remaining limitations gate the 🚧 rows:
 
-- **NCCL point-to-point — in progress.** `ncclSend` / `ncclRecv` are being added to the stub. Pipeline parallelism uses them directly, and NCCL's all-to-all is implemented as grouped point-to-point, so MoE / expert parallelism unlocks at the same time.
+- **Payload-free NCCL simulation.** Phantora models the timing and ordering of point-to-point transfers, but it does not transfer bytes between ranks. The Megatron pipeline test derives activation tensor metadata locally from the model configuration, so it can run on top of timing-only P2P. DeepSpeed and TorchTitan pipeline paths exchange shape, dtype, or object metadata over distributed send/recv before the activation transfer; because those metadata bytes are not delivered under simulation, those PP paths are not supported yet.
 - **DeepEP — on the roadmap.** Some recent MoE training stacks (e.g., DeepSeek-style models) bypass NCCL entirely and use [DeepEP](https://github.com/deepseek-ai/DeepEP) for expert dispatch/combine. We plan to add a DeepEP interception layer so those stacks can be simulated as well.
 
 Rows marked `—` mean the feature does not exist in that framework. If you'd like to help land any of the in-progress pieces sooner, contributions are very welcome — see [Contributing](#contributing).
@@ -242,7 +242,7 @@ We especially welcome data points that fall outside what is covered above — di
 Contributions of any size are welcome:
 
 - **Ground-truth measurements** to expand the validation matrix — see the [Contributing ground truth](#contributing-ground-truth) checklist above.
-- **NCCL coverage** — see the matrix in [Limited NCCL coverage](#limited-nccl-coverage). PRs that add `ncclSend`/`ncclRecv` (which would unblock pipeline parallelism), `ncclReduce`, `ncclBroadcast`, or any other unimplemented entry point are especially valuable.
+- **NCCL coverage** — see the matrix in [Limited NCCL coverage](#limited-nccl-coverage). PRs that add payload-aware support for metadata exchanges, `ncclReduce`, `ncclBroadcast`, or any other unimplemented entry point are especially valuable.
 - **New ML frameworks or models** — Phantora's design is framework-agnostic; small runtime patches let new PyTorch-based frameworks run unchanged.
 - **Bug reports and feature requests** — please file them on [GitHub Issues](https://github.com/QDelta/Phantora/issues).
 

--- a/phantora/cuda_call/src/capi.rs
+++ b/phantora/cuda_call/src/capi.rs
@@ -705,7 +705,12 @@ impl NcclCaller {
         }
         if self.group_counter == 0 {
             let mut responsed_calls = Vec::new();
+            let mut p2p_calls = Vec::new();
             for call in self.grouped_calls.drain(..) {
+                if matches!(call, CudaCall::NcclSend { .. } | CudaCall::NcclRecv { .. }) {
+                    p2p_calls.push(call);
+                    continue;
+                }
                 if let CudaCall::NcclCommInitRank { nranks, .. } = &call {
                     if *nranks > 1 {
                         responsed_calls.push(call.clone());
@@ -717,6 +722,9 @@ impl NcclCaller {
                 } else {
                     send_cuda_call(call);
                 }
+            }
+            if !p2p_calls.is_empty() {
+                send_cuda_call(CudaCall::NcclP2pGroup { calls: p2p_calls });
             }
             for call in responsed_calls {
                 match call {
@@ -922,6 +930,50 @@ pub extern "C" fn nccl_reduce_scatter(
             count,
             dtype: enum_to_nccl_datatype(dtype),
             op: enum_to_nccl_reduce_op(op),
+            comm: NcclComm { rank, id },
+            stream: CudaStream { device, id: stream },
+        })
+    });
+}
+
+#[no_mangle]
+pub extern "C" fn nccl_send(
+    count: usize,
+    dtype: i32,
+    peer: i32,
+    comm_id: *const ffi::c_char,
+    rank: i32,
+    device: i32,
+    stream: i32,
+) {
+    let id = get_comm_id(comm_id);
+    NCCL_CALLER.with_borrow_mut(|caller| {
+        caller.call(CudaCall::NcclSend {
+            count,
+            dtype: enum_to_nccl_datatype(dtype),
+            peer,
+            comm: NcclComm { rank, id },
+            stream: CudaStream { device, id: stream },
+        })
+    });
+}
+
+#[no_mangle]
+pub extern "C" fn nccl_recv(
+    count: usize,
+    dtype: i32,
+    peer: i32,
+    comm_id: *const ffi::c_char,
+    rank: i32,
+    device: i32,
+    stream: i32,
+) {
+    let id = get_comm_id(comm_id);
+    NCCL_CALLER.with_borrow_mut(|caller| {
+        caller.call(CudaCall::NcclRecv {
+            count,
+            dtype: enum_to_nccl_datatype(dtype),
+            peer,
             comm: NcclComm { rank, id },
             stream: CudaStream { device, id: stream },
         })

--- a/phantora/cuda_call/src/lib.rs
+++ b/phantora/cuda_call/src/lib.rs
@@ -186,6 +186,23 @@ pub enum CudaCall {
         comm: NcclComm,
         stream: CudaStream,
     },
+    NcclSend {
+        count: usize,
+        dtype: NcclDatatype,
+        peer: i32,
+        comm: NcclComm,
+        stream: CudaStream,
+    },
+    NcclRecv {
+        count: usize,
+        dtype: NcclDatatype,
+        peer: i32,
+        comm: NcclComm,
+        stream: CudaStream,
+    },
+    NcclP2pGroup {
+        calls: Vec<CudaCall>,
+    },
 
     ReadTimer(CudaStream),
 }

--- a/phantora/phantora/build.rs
+++ b/phantora/phantora/build.rs
@@ -16,7 +16,10 @@ fn main() {
             format!("{}/targets/x86_64-linux/include", cuda_home),
             format!("{}/targets/x86_64-linux/lib", cuda_home),
         ),
-        (format!("{}/include", cuda_home), format!("{}/lib64", cuda_home)),
+        (
+            format!("{}/include", cuda_home),
+            format!("{}/lib64", cuda_home),
+        ),
     ] {
         let inc_path = PathBuf::from(&inc);
         let lib_path = PathBuf::from(&lib);

--- a/phantora/phantora/src/cuda_estimate.rs
+++ b/phantora/phantora/src/cuda_estimate.rs
@@ -33,7 +33,7 @@ macro_rules! estimate {
             };
             // CUPTI hygiene: drain pending warmup records before the
             // measured window opens. Sync first to make sure the
-            // warmup kernels have actually completed (they're async,
+            // warmup GPU work has actually completed (it's async,
             // so their CUPTI records may not exist yet without sync).
             if $crate::cupti::enabled() {
                 assert_cuda!(cudaDeviceSynchronize());

--- a/phantora/phantora/src/cupti.rs
+++ b/phantora/phantora/src/cupti.rs
@@ -1,13 +1,13 @@
-//! CUPTI-based per-op kernel timing for the `estimate!` macro.
+//! CUPTI-based per-op GPU activity timing for the `estimate!` macro.
 //!
-//! Default is CUPTI kernel-only timing (CONCURRENT_KERNEL activity records).
+//! Default is CUPTI GPU activity timing (kernel, memcpy, and memset activity records).
 //! Set `PHANTORA_USE_CUPTI=0` (or `false`) to fall back to the older
 //! `cudaEventElapsedTime` path.
 //!
-//! CUPTI's CONCURRENT_KERNEL records contain GPU-clock timestamps captured
-//! by the driver when the kernel actually started and ended on the device.
+//! CUPTI activity records contain GPU-clock timestamps captured by the driver
+//! when kernels, memcpy, and memset operations actually started and ended on the device.
 //! Host stalls between the two `cudaEventRecord` calls are invisible to
-//! CUPTI, giving pure GPU kernel time.
+//! CUPTI, giving device activity time.
 
 use std::sync::OnceLock;
 
@@ -16,19 +16,17 @@ extern "C" {
     fn phantora_cupti_init() -> i32;
     fn phantora_cupti_clear();
     fn phantora_cupti_flush();
-    fn phantora_cupti_sum_kernel_ns() -> u64;
+    fn phantora_cupti_sum_activity_ns() -> u64;
 }
 
-/// Read the env var once and cache. Default is **on** — CUPTI gives
-/// kernel-only GPU time. Set `PHANTORA_USE_CUPTI=0` (or `false`) to
+/// Read the env var once and cache. Default is **on** — CUPTI gives GPU
+/// activity time. Set `PHANTORA_USE_CUPTI=0` (or `false`) to
 /// fall back to `cudaEventElapsedTime`.
 pub fn enabled() -> bool {
     static FLAG: OnceLock<bool> = OnceLock::new();
-    *FLAG.get_or_init(|| {
-        match std::env::var("PHANTORA_USE_CUPTI") {
-            Ok(v) => !(v == "0" || v.eq_ignore_ascii_case("false")),
-            Err(_) => true,
-        }
+    *FLAG.get_or_init(|| match std::env::var("PHANTORA_USE_CUPTI") {
+        Ok(v) => !(v == "0" || v.eq_ignore_ascii_case("false")),
+        Err(_) => true,
     })
 }
 
@@ -40,11 +38,14 @@ pub fn init() {
     }
     let r = unsafe { phantora_cupti_init() };
     if r != 0 {
-        panic!("CUPTI init failed (code {}) — cannot continue with PHANTORA_USE_CUPTI enabled", r);
+        panic!(
+            "CUPTI init failed (code {}) — cannot continue with PHANTORA_USE_CUPTI enabled",
+            r
+        );
     }
 }
 
-/// Reset the kernel-ns accumulator before a measurement window opens.
+/// Reset the activity-ns accumulator before a measurement window opens.
 #[inline]
 pub fn clear() {
     if enabled() {
@@ -53,14 +54,14 @@ pub fn clear() {
 }
 
 /// Force CUPTI to drain its activity buffers, then read the sum of
-/// kernel GPU time observed since the last `clear()`. Returns ns.
+/// GPU activity time observed since the last `clear()`. Returns ns.
 /// Returns 0 when CUPTI is disabled.
 #[inline]
 pub fn flush_and_sum_ns() -> u64 {
     if enabled() {
         unsafe {
             phantora_cupti_flush();
-            phantora_cupti_sum_kernel_ns()
+            phantora_cupti_sum_activity_ns()
         }
     } else {
         0

--- a/phantora/phantora/src/cupti_shim.c
+++ b/phantora/phantora/src/cupti_shim.c
@@ -19,13 +19,27 @@
 // counter is single-writer for that window once the flush returns.
 
 #include <cupti.h>
+#include <cupti_version.h>
 #include <stdatomic.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-static _Atomic uint64_t g_kernel_ns = 0;
+static _Atomic uint64_t g_activity_ns = 0;
+
+#if CUPTI_API_VERSION >= 130000
+#define PHANTORA_CUPTI_MEMCPY_RECORD CUpti_ActivityMemcpy6
+#else
+#define PHANTORA_CUPTI_MEMCPY_RECORD CUpti_ActivityMemcpy5
+#endif
+
+static void add_activity_duration(uint64_t start, uint64_t end)
+{
+    if (start == 0 && end == 0) return;
+    if (end < start) return;
+    atomic_fetch_add_explicit(&g_activity_ns, end - start, memory_order_relaxed);
+}
 
 static void CUPTIAPI buf_requested(uint8_t **buffer, size_t *size,
                                    size_t *max_records)
@@ -53,9 +67,16 @@ static void CUPTIAPI buf_completed(CUcontext ctx, uint32_t stream_id,
             // upgraded to a CUDA toolkit with newer kernel records,
             // bump this cast.
             CUpti_ActivityKernel8 *k = (CUpti_ActivityKernel8 *)r;
-            atomic_fetch_add_explicit(&g_kernel_ns,
-                                      k->end - k->start,
-                                      memory_order_relaxed);
+            add_activity_duration(k->start, k->end);
+        } else if (r->kind == CUPTI_ACTIVITY_KIND_MEMCPY) {
+            PHANTORA_CUPTI_MEMCPY_RECORD *m = (PHANTORA_CUPTI_MEMCPY_RECORD *)r;
+            add_activity_duration(m->start, m->end);
+        } else if (r->kind == CUPTI_ACTIVITY_KIND_MEMCPY2) {
+            CUpti_ActivityMemcpyPtoP4 *m = (CUpti_ActivityMemcpyPtoP4 *)r;
+            add_activity_duration(m->start, m->end);
+        } else if (r->kind == CUPTI_ACTIVITY_KIND_MEMSET) {
+            CUpti_ActivityMemset4 *m = (CUpti_ActivityMemset4 *)r;
+            add_activity_duration(m->start, m->end);
         }
     }
     free(buffer);
@@ -69,13 +90,19 @@ int phantora_cupti_init(void)
     if (r1 != CUPTI_SUCCESS) return (int)r1;
     CUptiResult r2 = cuptiActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL);
     if (r2 != CUPTI_SUCCESS) return (int)r2;
+    CUptiResult r3 = cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMCPY);
+    if (r3 != CUPTI_SUCCESS) return (int)r3;
+    CUptiResult r4 = cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMCPY2);
+    if (r4 != CUPTI_SUCCESS) return (int)r4;
+    CUptiResult r5 = cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMSET);
+    if (r5 != CUPTI_SUCCESS) return (int)r5;
     initialised = 1;
     return 0;
 }
 
 void phantora_cupti_clear(void)
 {
-    atomic_store_explicit(&g_kernel_ns, 0, memory_order_release);
+    atomic_store_explicit(&g_activity_ns, 0, memory_order_release);
 }
 
 void phantora_cupti_flush(void)
@@ -83,7 +110,7 @@ void phantora_cupti_flush(void)
     cuptiActivityFlushAll(0);
 }
 
-uint64_t phantora_cupti_sum_kernel_ns(void)
+uint64_t phantora_cupti_sum_activity_ns(void)
 {
-    return atomic_load_explicit(&g_kernel_ns, memory_order_acquire);
+    return atomic_load_explicit(&g_activity_ns, memory_order_acquire);
 }

--- a/phantora/phantora/src/event_queue.rs
+++ b/phantora/phantora/src/event_queue.rs
@@ -523,13 +523,13 @@ impl EventQueue {
                     match self.started.get_mut(&id) {
                         Some(started_record) => {
                             if started_record.start_time < new_start_time {
+                                let delta = new_start_time - started_record.start_time;
                                 started_record.start_time = new_start_time;
-                                let found = self.event_queue.change_priority_by(
-                                    &Event::End(id),
-                                    |Reverse((time, _))| {
-                                        *time += new_start_time - started_record.start_time
-                                    },
-                                );
+                                let found = self
+                                    .event_queue
+                                    .change_priority_by(&Event::End(id), |Reverse((time, _))| {
+                                        *time += delta
+                                    });
                                 assert!(found, "id: {}", id);
                             }
                         }

--- a/phantora/phantora/src/simulator.rs
+++ b/phantora/phantora/src/simulator.rs
@@ -115,7 +115,7 @@ pub type CommMeta = CudaCall;
 #[repr(transparent)]
 pub struct NodeId(pub HostId);
 
-#[derive(PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(transparent)]
 pub struct NcclId(pub [u8; 128]);
 
@@ -140,6 +140,46 @@ struct SplitInfo {
 struct SplitWaiting {
     joined_ranks: HashMap<i32, SplitInfo>,
     waiting_for: HashSet<i32>,
+}
+
+type P2PKey = (NcclId, i32, i32);
+
+#[derive(Clone, Copy)]
+enum P2PCallKind {
+    Send,
+    Recv,
+}
+
+struct P2PCallInfo {
+    kind: P2PCallKind,
+    key: P2PKey,
+    stream: CudaStream,
+    count: usize,
+    dtype: NcclDatatype,
+}
+
+struct P2PFlowEndpoint {
+    host: HostId,
+    stream: CudaStream,
+    curr_time: i64,
+    count: usize,
+    dtype: NcclDatatype,
+    // Nodes that gate this one matched network flow.
+    //
+    // Ungrouped P2P: these are real stream-ordered start/end points created with
+    // `add_event`, so the CUDA stream is occupied until the matched flow ends.
+    //
+    // Grouped P2P: these are raw off-stream flow_start/flow_end points created
+    // with `add_action_or_point`.  The stream-visible group_start/group_end
+    // shell is separate, which lets multiple internal flows run concurrently
+    // instead of being serialized by CUDA stream order.
+    flow_start: EventId,
+    flow_end: EventId,
+    // Keeps this local flow endpoint from starting before it has found a peer.
+    // Both grouped and ungrouped P2P create one unmatched barrier per endpoint;
+    // matching releases the two endpoint barriers and then the scheduled flow is
+    // gated by both sides' flow_start points.
+    unmatched_barrier: EventId,
 }
 
 struct CCWaiting {
@@ -172,6 +212,10 @@ pub struct Simulator {
     allreduce_waiting: HashMap<NcclId, VecDeque<CCWaiting>>,
     allgather_waiting: HashMap<NcclId, VecDeque<CCWaiting>>,
     reduce_scatter_waiting: HashMap<NcclId, VecDeque<CCWaiting>>,
+    // P2P key = (comm_id, sender_rank, receiver_rank). FIFO queues preserve
+    // NCCL's peer ordering for repeated sends/receives.
+    send_waiting: HashMap<P2PKey, VecDeque<P2PFlowEndpoint>>,
+    recv_waiting: HashMap<P2PKey, VecDeque<P2PFlowEndpoint>>,
 }
 
 fn incr_nccl_id(id: &mut [u8; 128]) -> [u8; 128] {
@@ -230,6 +274,8 @@ impl Simulator {
             allreduce_waiting: HashMap::new(),
             allgather_waiting: HashMap::new(),
             reduce_scatter_waiting: HashMap::new(),
+            send_waiting: HashMap::new(),
+            recv_waiting: HashMap::new(),
         }
     }
 
@@ -513,6 +559,21 @@ impl Simulator {
                 comm,
                 stream,
             ),
+            CudaCall::NcclSend {
+                count,
+                dtype,
+                peer,
+                comm,
+                stream,
+            } => self.nccl_ungrouped_send(host.host, curr_time, count, dtype, peer, comm, stream),
+            CudaCall::NcclRecv {
+                count,
+                dtype,
+                peer,
+                comm,
+                stream,
+            } => self.nccl_ungrouped_recv(host.host, curr_time, count, dtype, peer, comm, stream),
+            CudaCall::NcclP2pGroup { calls } => self.nccl_grouped_p2p(host.host, curr_time, calls),
 
             CudaCall::ReadTimer(stream) => {
                 self.read_timer(host, curr_time, stream);
@@ -950,6 +1011,368 @@ impl Simulator {
                 .unwrap(),
             );
         }
+    }
+
+    fn nccl_ungrouped_send(
+        &mut self,
+        host: HostId,
+        curr_time: i64,
+        count: usize,
+        dtype: NcclDatatype,
+        peer: i32,
+        comm: NcclComm,
+        stream: CudaStream,
+    ) {
+        self.nccl_ungrouped_p2p(
+            P2PCallKind::Send,
+            host,
+            curr_time,
+            count,
+            dtype,
+            peer,
+            comm,
+            stream,
+        );
+    }
+
+    fn nccl_ungrouped_recv(
+        &mut self,
+        host: HostId,
+        curr_time: i64,
+        count: usize,
+        dtype: NcclDatatype,
+        peer: i32,
+        comm: NcclComm,
+        stream: CudaStream,
+    ) {
+        self.nccl_ungrouped_p2p(
+            P2PCallKind::Recv,
+            host,
+            curr_time,
+            count,
+            dtype,
+            peer,
+            comm,
+            stream,
+        );
+    }
+
+    fn nccl_ungrouped_p2p(
+        &mut self,
+        kind: P2PCallKind,
+        host: HostId,
+        curr_time: i64,
+        count: usize,
+        dtype: NcclDatatype,
+        peer: i32,
+        comm: NcclComm,
+        stream: CudaStream,
+    ) {
+        // Ungrouped NCCL P2P is stream ordered: one send/recv call occupies its
+        // CUDA stream until the matched network flow completes.  Each endpoint
+        // owns a private zero-time barrier, so the same match/enqueue helper can
+        // either store this endpoint or match it and release both barriers.
+        let key = Self::p2p_key(kind, comm, peer);
+        let unmatched_barrier = self.queue.add_action_or_point(vec![None], None, curr_time);
+        let endpoint = self.create_ungrouped_p2p_endpoint(
+            host,
+            stream,
+            curr_time,
+            count,
+            dtype,
+            unmatched_barrier,
+        );
+        self.match_or_enqueue_p2p_endpoint(kind, key, endpoint);
+    }
+
+    fn nccl_grouped_p2p(&mut self, host: HostId, curr_time: i64, calls: Vec<CudaCall>) {
+        let mut calls_by_stream: HashMap<CudaStream, Vec<P2PCallInfo>> = HashMap::new();
+        for call in calls {
+            let call_info = match call {
+                CudaCall::NcclSend {
+                    count,
+                    dtype,
+                    peer,
+                    comm,
+                    stream,
+                } => Some(P2PCallInfo {
+                    kind: P2PCallKind::Send,
+                    key: Self::p2p_key(P2PCallKind::Send, comm, peer),
+                    stream,
+                    count,
+                    dtype,
+                }),
+                CudaCall::NcclRecv {
+                    count,
+                    dtype,
+                    peer,
+                    comm,
+                    stream,
+                } => Some(P2PCallInfo {
+                    kind: P2PCallKind::Recv,
+                    key: Self::p2p_key(P2PCallKind::Recv, comm, peer),
+                    stream,
+                    count,
+                    dtype,
+                }),
+                other => {
+                    log::warn!("Ignoring non-P2P call in NcclP2pGroup: {:?}", other);
+                    None
+                }
+            };
+            if let Some(call_info) = call_info {
+                calls_by_stream
+                    .entry(call_info.stream)
+                    .or_default()
+                    .push(call_info);
+            }
+        }
+        if calls_by_stream.is_empty() {
+            return;
+        }
+
+        // Grouped NCCL P2P is modeled as a single stream-visible grouped op per
+        // stream, plus independent raw DAG communication flows.
+        //
+        // The group start/end points preserve CUDA stream semantics:
+        //   previous stream work -> group_start -> group_end -> following work
+        //
+        // Individual P2P flows are *not* stream events.  A matched pair creates a
+        // raw Action::Communication node between off-stream flow_start/flow_end
+        // points, so flow A may run while flow B is still unmatched.
+        //
+        // Each stream group has:
+        //   group_barrier -> prevents internal flow points from firing while the
+        //                    group's DAG is still being constructed.
+        //   group_start   -> stream-ordered start of the fused grouped NCCL op.
+        //   group_end     -> stream-ordered end; following stream work waits here.
+        //
+        // Each P2P call in the group has:
+        //   unmatched_barrier -> held until this call matches its peer.
+        //   flow_start/end    -> raw DAG points, not stream events.
+        //
+        // Once the setup is complete, group_barrier is released.  Matching a pair
+        // releases only the two per-call unmatched barriers and attaches the real
+        // flow events to the corresponding flow_end points.  Since group_end
+        // depends on every flow_end, the stream advances only after all internal
+        // transfers finish.
+        for (stream, grouped_calls) in calls_by_stream {
+            let group_barrier = self.queue.add_action_or_point(vec![None], None, curr_time);
+            let group_start = Self::add_event(
+                &mut self.torch_estimator,
+                &mut self.stream_info,
+                &mut self.queue,
+                (host.clone(), stream),
+                vec![Some(group_barrier)],
+                None,
+                curr_time,
+            );
+
+            let mut flow_setups = Vec::new();
+            for call in grouped_calls {
+                let unmatched_barrier = self.queue.add_action_or_point(vec![None], None, curr_time);
+                // Internal grouped flows are raw DAG points, not stream events:
+                // the per-flow barrier controls matching, while group_end below
+                // is the only stream-visible join for following work.
+                let flow_start = self.queue.add_action_or_point(
+                    vec![Some(group_start), Some(unmatched_barrier)],
+                    None,
+                    curr_time,
+                );
+                let flow_end =
+                    self.queue
+                        .add_action_or_point(vec![Some(flow_start)], None, curr_time);
+                flow_setups.push((call, unmatched_barrier, flow_start, flow_end));
+            }
+
+            let mut group_end_dependencies = vec![Some(group_start)];
+            group_end_dependencies.extend(
+                flow_setups
+                    .iter()
+                    .map(|(_, _, _, flow_end)| Some(*flow_end)),
+            );
+            Self::add_event(
+                &mut self.torch_estimator,
+                &mut self.stream_info,
+                &mut self.queue,
+                (host.clone(), stream),
+                group_end_dependencies,
+                None,
+                curr_time,
+            );
+
+            for (call, unmatched_barrier, flow_start, flow_end) in flow_setups {
+                let endpoint = P2PFlowEndpoint {
+                    host: host.clone(),
+                    stream: call.stream,
+                    curr_time,
+                    count: call.count,
+                    dtype: call.dtype,
+                    flow_start,
+                    flow_end,
+                    unmatched_barrier,
+                };
+                self.match_or_enqueue_p2p_endpoint(call.kind, call.key, endpoint);
+            }
+
+            self.queue.remove_none_dependency(group_barrier);
+        }
+    }
+
+    fn p2p_key(kind: P2PCallKind, comm: NcclComm, peer: i32) -> P2PKey {
+        match kind {
+            P2PCallKind::Send => (NcclId(comm.id), comm.rank, peer),
+            P2PCallKind::Recv => (NcclId(comm.id), peer, comm.rank),
+        }
+    }
+
+    fn create_ungrouped_p2p_endpoint(
+        &mut self,
+        host: HostId,
+        stream: CudaStream,
+        curr_time: i64,
+        count: usize,
+        dtype: NcclDatatype,
+        unmatched_barrier: EventId,
+    ) -> P2PFlowEndpoint {
+        let flow_start = Self::add_event(
+            &mut self.torch_estimator,
+            &mut self.stream_info,
+            &mut self.queue,
+            (host.clone(), stream),
+            vec![Some(unmatched_barrier)],
+            None,
+            curr_time,
+        );
+        let flow_end = Self::add_event(
+            &mut self.torch_estimator,
+            &mut self.stream_info,
+            &mut self.queue,
+            (host.clone(), stream),
+            vec![Some(flow_start)],
+            None,
+            curr_time,
+        );
+
+        P2PFlowEndpoint {
+            host,
+            stream,
+            curr_time,
+            count,
+            dtype,
+            flow_start,
+            flow_end,
+            unmatched_barrier,
+        }
+    }
+
+    fn match_or_enqueue_p2p_endpoint(
+        &mut self,
+        kind: P2PCallKind,
+        key: P2PKey,
+        endpoint: P2PFlowEndpoint,
+    ) {
+        if let Some(peer_endpoint) = self.pop_matching_peer_endpoint(kind, &key) {
+            self.schedule_matched_p2p_flow(kind, endpoint, peer_endpoint, &key);
+        } else {
+            self.enqueue_unmatched_p2p_endpoint(kind, key, endpoint);
+        }
+    }
+
+    fn pop_matching_peer_endpoint(
+        &mut self,
+        kind: P2PCallKind,
+        key: &P2PKey,
+    ) -> Option<P2PFlowEndpoint> {
+        match kind {
+            P2PCallKind::Send => Self::pop_p2p_endpoint(&mut self.recv_waiting, key),
+            P2PCallKind::Recv => Self::pop_p2p_endpoint(&mut self.send_waiting, key),
+        }
+    }
+
+    fn pop_p2p_endpoint(
+        waiting_map: &mut HashMap<P2PKey, VecDeque<P2PFlowEndpoint>>,
+        key: &P2PKey,
+    ) -> Option<P2PFlowEndpoint> {
+        let endpoint = waiting_map.get_mut(key).and_then(|queue| queue.pop_front());
+        if waiting_map.get(key).map_or(false, |queue| queue.is_empty()) {
+            waiting_map.remove(key);
+        }
+        endpoint
+    }
+
+    fn enqueue_unmatched_p2p_endpoint(
+        &mut self,
+        kind: P2PCallKind,
+        key: P2PKey,
+        endpoint: P2PFlowEndpoint,
+    ) {
+        let waiting_map = match kind {
+            P2PCallKind::Send => &mut self.send_waiting,
+            P2PCallKind::Recv => &mut self.recv_waiting,
+        };
+        waiting_map.entry(key).or_default().push_back(endpoint);
+    }
+
+    fn schedule_matched_p2p_flow(
+        &mut self,
+        kind: P2PCallKind,
+        endpoint: P2PFlowEndpoint,
+        peer_endpoint: P2PFlowEndpoint,
+        key: &P2PKey,
+    ) {
+        let (send_endpoint, recv_endpoint) = match kind {
+            P2PCallKind::Send => (endpoint, peer_endpoint),
+            P2PCallKind::Recv => (peer_endpoint, endpoint),
+        };
+        Self::schedule_p2p_flow(&mut self.queue, send_endpoint, recv_endpoint, key);
+    }
+
+    fn release_unmatched_p2p_barrier(queue: &mut EventQueue, endpoint: &P2PFlowEndpoint) {
+        queue.remove_none_dependency(endpoint.unmatched_barrier);
+    }
+
+    fn schedule_p2p_flow(
+        queue: &mut EventQueue,
+        send: P2PFlowEndpoint,
+        recv: P2PFlowEndpoint,
+        key: &P2PKey,
+    ) {
+        let send_bytes = send.count * send.dtype.size();
+        let recv_bytes = recv.count * recv.dtype.size();
+        if send_bytes != recv_bytes {
+            log::warn!(
+                "Mismatched NCCL P2P sizes for {}->{}: send={} recv={}",
+                key.1,
+                key.2,
+                send_bytes,
+                recv_bytes
+            );
+        }
+        let flow = netsim::Flow::new(send_bytes, &send.host.hostname, &recv.host.hostname, None);
+
+        let curr_time = send.curr_time.max(recv.curr_time);
+        let flow_event = queue.add_action_or_point(
+            vec![Some(send.flow_start), Some(recv.flow_start)],
+            Some(Action::Communication(
+                flow,
+                CudaCall::NcclSend {
+                    count: send_bytes,
+                    dtype: NcclDatatype::U8,
+                    peer: key.2,
+                    comm: NcclComm {
+                        rank: key.1,
+                        id: key.0 .0,
+                    },
+                    stream: send.stream.clone(),
+                },
+            )),
+            curr_time,
+        );
+        queue.add_dependency(send.flow_end, Some(flow_event));
+        queue.add_dependency(recv.flow_end, Some(flow_event));
+        Self::release_unmatched_p2p_barrier(queue, &send);
+        Self::release_unmatched_p2p_barrier(queue, &recv);
     }
 
     fn nccl_call(

--- a/phantora/phantora/src/torch_call.rs
+++ b/phantora/phantora/src/torch_call.rs
@@ -537,6 +537,104 @@ impl TorchCallMsg {
                     None
                 }
             },
+            "aten::masked_fill" => match self.args.as_slice() {
+                [Tensor(shape, kind, _), Tensor(mask_shape, mask_kind, _), ..] => {
+                    Some(TorchCallInfo::MaskedFill(
+                        TensorInfo {
+                            shape: shape.clone(),
+                            dtype: *kind,
+                        },
+                        TensorInfo {
+                            shape: mask_shape.clone(),
+                            dtype: *mask_kind,
+                        },
+                    ))
+                }
+                _ => {
+                    log::warn!("{} args not match: {:?}", self.name, self.args);
+                    None
+                }
+            },
+            "aten::masked_fill_" => match self.args.as_slice() {
+                [Tensor(shape, kind, _), Tensor(mask_shape, mask_kind, _), ..] => {
+                    Some(TorchCallInfo::MaskedFill_(
+                        TensorInfo {
+                            shape: shape.clone(),
+                            dtype: *kind,
+                        },
+                        TensorInfo {
+                            shape: mask_shape.clone(),
+                            dtype: *mask_kind,
+                        },
+                    ))
+                }
+                _ => {
+                    log::warn!("{} args not match: {:?}", self.name, self.args);
+                    None
+                }
+            },
+            "aten::dropout" => match self.args.as_slice() {
+                [Tensor(shape, kind, _), Double(p), Bool(train)] => Some(TorchCallInfo::Dropout(
+                    TensorInfo {
+                        shape: shape.clone(),
+                        dtype: *kind,
+                    },
+                    (*p * 1_000_000.0).round() as i64,
+                    *train,
+                )),
+                _ => {
+                    log::warn!("{} args not match: {:?}", self.name, self.args);
+                    None
+                }
+            },
+            "aten::native_dropout" => match self.args.as_slice() {
+                [Tensor(shape, kind, _), Double(p), Bool(train)] => {
+                    Some(TorchCallInfo::NativeDropout(
+                        TensorInfo {
+                            shape: shape.clone(),
+                            dtype: *kind,
+                        },
+                        (*p * 1_000_000.0).round() as i64,
+                        *train,
+                    ))
+                }
+                _ => {
+                    log::warn!("{} args not match: {:?}", self.name, self.args);
+                    None
+                }
+            },
+            "aten::native_dropout_backward" => match self.args.as_slice() {
+                [Tensor(grad_shape, grad_kind, _), Tensor(mask_shape, mask_kind, _), Double(scale)] => {
+                    Some(TorchCallInfo::NativeDropoutBackward(
+                        TensorInfo {
+                            shape: grad_shape.clone(),
+                            dtype: *grad_kind,
+                        },
+                        TensorInfo {
+                            shape: mask_shape.clone(),
+                            dtype: *mask_kind,
+                        },
+                        (*scale * 1_000_000.0).round() as i64,
+                    ))
+                }
+                _ => {
+                    log::warn!("{} args not match: {:?}", self.name, self.args);
+                    None
+                }
+            },
+            "aten::_fused_dropout" => match self.args.as_slice() {
+                [Tensor(shape, kind, _), Double(p)] => Some(TorchCallInfo::FusedDropout(
+                    TensorInfo {
+                        shape: shape.clone(),
+                        dtype: *kind,
+                    },
+                    (*p * 1_000_000.0).round() as i64,
+                )),
+                _ => {
+                    log::warn!("{} args not match: {:?}", self.name, self.args);
+                    None
+                }
+            },
             "aten::where" => match self.args.as_slice() {
                 [Tensor(shape1, kind1, _), Tensor(shape2, kind2, _), Tensor(shape3, kind3, _)] => {
                     Some(TorchCallInfo::Where(
@@ -573,6 +671,44 @@ impl TorchCallMsg {
             },
             "aten::sqrt" => match self.args.as_slice() {
                 [Tensor(shape, kind, _)] => Some(TorchCallInfo::Sqrt(TensorInfo {
+                    shape: shape.clone(),
+                    dtype: *kind,
+                })),
+                _ => {
+                    log::warn!("{} args not match: {:?}", self.name, self.args);
+                    None
+                }
+            },
+            "aten::gelu" => match self.args.as_slice() {
+                [Tensor(shape, kind, _), ..] => Some(TorchCallInfo::Gelu(TensorInfo {
+                    shape: shape.clone(),
+                    dtype: *kind,
+                })),
+                _ => {
+                    log::warn!("{} args not match: {:?}", self.name, self.args);
+                    None
+                }
+            },
+            "aten::gelu_backward" => match self.args.as_slice() {
+                [Tensor(grad_shape, grad_kind, _), Tensor(self_shape, self_kind, _), ..] => {
+                    Some(TorchCallInfo::GeluBackward(
+                        TensorInfo {
+                            shape: grad_shape.clone(),
+                            dtype: *grad_kind,
+                        },
+                        TensorInfo {
+                            shape: self_shape.clone(),
+                            dtype: *self_kind,
+                        },
+                    ))
+                }
+                _ => {
+                    log::warn!("{} args not match: {:?}", self.name, self.args);
+                    None
+                }
+            },
+            "aten::sum" => match self.args.as_slice() {
+                [Tensor(shape, kind, _), ..] => Some(TorchCallInfo::Sum(TensorInfo {
                     shape: shape.clone(),
                     dtype: *kind,
                 })),
@@ -835,8 +971,17 @@ pub enum TorchCallInfo {
     AddCDiv_(TensorInfo, TensorInfo, TensorInfo),
     ForeachAddCMul_(Vec<TensorInfo>, Vec<TensorInfo>, Vec<TensorInfo>),
     ForeachAddCDiv_(Vec<TensorInfo>, Vec<TensorInfo>, Vec<TensorInfo>),
+    MaskedFill(TensorInfo, TensorInfo),
+    MaskedFill_(TensorInfo, TensorInfo),
+    Dropout(TensorInfo, i64, bool),
+    NativeDropout(TensorInfo, i64, bool),
+    NativeDropoutBackward(TensorInfo, TensorInfo, i64),
+    FusedDropout(TensorInfo, i64),
     Where(TensorInfo, TensorInfo, TensorInfo),
     WhereScalar(TensorInfo, TensorInfo),
+    Gelu(TensorInfo),
+    GeluBackward(TensorInfo, TensorInfo),
+    Sum(TensorInfo),
     Sqrt(TensorInfo),
     Softmax(TensorInfo, i64),
     SoftmaxBackward(TensorInfo, TensorInfo, i64),

--- a/phantora/phantora/src/torch_estimate.rs
+++ b/phantora/phantora/src/torch_estimate.rs
@@ -254,6 +254,61 @@ impl TorchEstimator {
                 );
                 dur
             }
+            TorchCallInfo::MaskedFill(info, mask_info) => {
+                let t = self.allocate(info);
+                let mask = self.allocate(mask_info);
+                let (result, dur) = estimate_torch!(niter, t.masked_fill(&mask, -10000.0));
+                self.cache(result);
+                dur
+            }
+            TorchCallInfo::MaskedFill_(info, mask_info) => {
+                let mut t = self.allocate(info);
+                let mask = self.allocate(mask_info);
+                let (result, dur) = estimate_torch!(niter, t.masked_fill_(&mask, -10000.0));
+                self.cache(result);
+                dur
+            }
+            TorchCallInfo::Dropout(info, p_millionths, train) => {
+                let t = self.allocate(info);
+                let (result, dur) =
+                    estimate_torch!(niter, t.dropout(*p_millionths as f64 / 1_000_000.0, *train));
+                self.cache(result);
+                dur
+            }
+            TorchCallInfo::NativeDropout(info, p_millionths, train) => {
+                let t = self.allocate(info);
+                let ((result, mask), dur) = estimate_torch!(
+                    niter,
+                    t.native_dropout(*p_millionths as f64 / 1_000_000.0, *train)
+                );
+                self.cache(result);
+                self.cache(mask);
+                dur
+            }
+            TorchCallInfo::NativeDropoutBackward(grad_info, mask_info, scale_millionths) => {
+                let grad = self.allocate(grad_info);
+                let mask = self.allocate(mask_info);
+                let (result, dur) = estimate_torch!(
+                    niter,
+                    Tensor::native_dropout_backward(
+                        &grad,
+                        &mask,
+                        *scale_millionths as f64 / 1_000_000.0
+                    )
+                );
+                self.cache(result);
+                dur
+            }
+            TorchCallInfo::FusedDropout(info, p_millionths) => {
+                let t = self.allocate(info);
+                let ((result, mask), dur) = estimate_torch!(
+                    niter,
+                    t.internal_fused_dropout(*p_millionths as f64 / 1_000_000.0)
+                );
+                self.cache(result);
+                self.cache(mask);
+                dur
+            }
             TorchCallInfo::Where(info1, info2, info3) => {
                 let t1 = self.allocate(info1);
                 let t2 = self.allocate(info2);
@@ -266,6 +321,25 @@ impl TorchEstimator {
                 let t1 = self.allocate(info1);
                 let t2 = self.allocate(info2);
                 let (result, dur) = estimate_torch!(niter, t2.where_scalarother(&t1, 1));
+                self.cache(result);
+                dur
+            }
+            TorchCallInfo::Gelu(info) => {
+                let t = self.allocate(info);
+                let (result, dur) = estimate_torch!(niter, t.gelu("none"));
+                self.cache(result);
+                dur
+            }
+            TorchCallInfo::GeluBackward(grad_info, input_info) => {
+                let grad = self.allocate(grad_info);
+                let input = self.allocate(input_info);
+                let (result, dur) = estimate_torch!(niter, input.gelu_backward(&grad, "none"));
+                self.cache(result);
+                dur
+            }
+            TorchCallInfo::Sum(info) => {
+                let t = self.allocate(info);
+                let (result, dur) = estimate_torch!(niter, t.sum(info.dtype));
                 self.cache(result);
                 dur
             }

--- a/stub/nccl.c
+++ b/stub/nccl.c
@@ -339,7 +339,10 @@ ncclSend(const void* sendbuff,
          ncclComm_t comm,
          cudaStream_t stream)
 {
-    NOT_IMPLEMENTED;
+    struct phantora_cudaStream stream_ = phantora_cudaStream(stream);
+    nccl_send(
+      count, datatype, peer, comm->id, comm->rank, stream_.device, stream_.id);
+    return ncclSuccess;
 }
 
 ncclResult_t
@@ -350,5 +353,8 @@ ncclRecv(void* recvbuff,
          ncclComm_t comm,
          cudaStream_t stream)
 {
-    NOT_IMPLEMENTED;
+    struct phantora_cudaStream stream_ = phantora_cudaStream(stream);
+    nccl_recv(
+      count, datatype, peer, comm->id, comm->rank, stream_.device, stream_.id);
+    return ncclSuccess;
 }

--- a/tests/test_megatron.py
+++ b/tests/test_megatron.py
@@ -21,7 +21,11 @@ from megatron.core.distributed import (
 from megatron.core.models.gpt.gpt_model import GPTModel
 from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_local_spec
 from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
-from megatron.core.pipeline_parallel.schedules import forward_backward_no_pipelining
+from megatron.core.pipeline_parallel.schedules import (
+    forward_backward_no_pipelining,
+    forward_backward_pipelining_with_interleaving,
+    forward_backward_pipelining_without_interleaving,
+)
 from megatron.core.tensor_parallel.random import model_parallel_cuda_manual_seed
 from megatron.core.transformer.enums import AttnBackend
 from megatron.core.transformer.module import Float16Module
@@ -83,6 +87,9 @@ class NullTokenizer(MegatronTokenizer):
 
 def get_model(
     tensor_parallel_size,
+    pipeline_model_parallel_size,
+    virtual_pipeline_model_parallel_size,
+    vp_stage,
     num_layers,
     hidden_size,
     ffn_hidden_size,
@@ -93,6 +100,8 @@ def get_model(
 ):
     transformer_config = TransformerConfig(
         tensor_model_parallel_size=tensor_parallel_size,
+        pipeline_model_parallel_size=pipeline_model_parallel_size,
+        virtual_pipeline_model_parallel_size=virtual_pipeline_model_parallel_size,
         num_layers=num_layers,
         hidden_size=hidden_size,
         ffn_hidden_size=ffn_hidden_size,
@@ -100,6 +109,7 @@ def get_model(
         perform_initialization=False,
         bf16=True,
         params_dtype=torch.bfloat16,
+        pipeline_dtype=torch.bfloat16,
         attention_backend=AttnBackend.flash,
         recompute_granularity="selective" if recompute_activations else None,
     )
@@ -111,6 +121,13 @@ def get_model(
             transformer_layer_spec=get_gpt_layer_local_spec(),
             vocab_size=vocab_size,
             max_sequence_length=sequence_length,
+            pre_process=parallel_state.is_pipeline_first_stage(
+                ignore_virtual=False, vp_stage=vp_stage
+            ),
+            post_process=parallel_state.is_pipeline_last_stage(
+                ignore_virtual=False, vp_stage=vp_stage
+            ),
+            vp_stage=vp_stage,
         ),
     )
 
@@ -137,9 +154,14 @@ def get_optimizer(model):
         clip_grad=0.0,  # no grad clipping because norm depends on communication and can cause error in simulation
     )
 
-    optim = get_megatron_optimizer(optim_config, [model], use_gloo_process_groups=False)
+    model_chunks = model if isinstance(model, list) else [model]
+    optim = get_megatron_optimizer(optim_config, model_chunks, use_gloo_process_groups=False)
 
     return optim
+
+
+def iter_model_chunks(model):
+    return model if isinstance(model, list) else [model]
 
 
 def get_train_data_iterator(vocab_size, micro_batch_size):
@@ -180,6 +202,8 @@ def forward_step_func(device, data_iterator, model):
 
 def main(
     tensor_parallel_size,
+    pipeline_model_parallel_size,
+    virtual_pipeline_model_parallel_size,
     num_layers,
     hidden_size,
     ffn_hidden_size,
@@ -201,43 +225,113 @@ def main(
         world_size=world_size, rank=rank, device_id=device
     )
     parallel_state.initialize_model_parallel(
-        tensor_model_parallel_size=tensor_parallel_size
+        tensor_model_parallel_size=tensor_parallel_size,
+        pipeline_model_parallel_size=pipeline_model_parallel_size,
+        virtual_pipeline_model_parallel_size=virtual_pipeline_model_parallel_size,
     )
 
     model_parallel_cuda_manual_seed(42)
 
-    model = get_model(
-        tensor_parallel_size,
-        num_layers,
-        hidden_size,
-        ffn_hidden_size,
-        num_attention_heads,
-        vocab_size,
-        4096,
-        recompute_activations
-    )
-    model = model.to(device)
-    model.train()
+    if virtual_pipeline_model_parallel_size is None:
+        model = get_model(
+            tensor_parallel_size,
+            pipeline_model_parallel_size,
+            None,
+            None,
+            num_layers,
+            hidden_size,
+            ffn_hidden_size,
+            num_attention_heads,
+            vocab_size,
+            4096,
+            recompute_activations
+        )
+        model = model.to(device)
+        model.train()
+    else:
+        model = []
+        for vp_stage in range(virtual_pipeline_model_parallel_size):
+            parallel_state.set_virtual_pipeline_model_parallel_rank(vp_stage)
+            model_chunk = get_model(
+                tensor_parallel_size,
+                pipeline_model_parallel_size,
+                virtual_pipeline_model_parallel_size,
+                vp_stage,
+                num_layers,
+                hidden_size,
+                ffn_hidden_size,
+                num_attention_heads,
+                vocab_size,
+                4096,
+                recompute_activations
+            )
+            model_chunk = model_chunk.to(device)
+            model_chunk.train()
+            model.append(model_chunk)
+        parallel_state.set_virtual_pipeline_model_parallel_rank(0)
+
+        no_sync_funcs = [model_chunk.no_sync for model_chunk in model]
+        for model_chunk in model:
+            model_chunk.config.no_sync_func = no_sync_funcs
+            model_chunk.config.finalize_model_grads_func = finalize_model_grads
+
     if rank == 0:
-        print(f"Model size: {sum(p.numel() for p in model.parameters())}")
+        model_size = sum(
+            p.numel()
+            for model_chunk in iter_model_chunks(model)
+            for p in model_chunk.parameters()
+        )
+        print(f"Model size: {model_size}")
     optim = get_optimizer(model)
-    train_iterator = get_train_data_iterator(vocab_size, micro_batch_size)
+
+    pp_size = pipeline_model_parallel_size
+    num_microbatches = max(gradient_accumulation, pp_size * 4) \
+        if pp_size > 1 else gradient_accumulation
 
     duras = []
     duras_wall = []
     for i in range(iterations):
+        if virtual_pipeline_model_parallel_size is None:
+            train_iterator = get_train_data_iterator(vocab_size, micro_batch_size)
+        else:
+            train_iterator = [
+                get_train_data_iterator(vocab_size, micro_batch_size)
+                for _ in range(virtual_pipeline_model_parallel_size)
+            ]
         start, start_wall = time_pair()
-        model.zero_grad_buffer()
+        for model_chunk in iter_model_chunks(model):
+            model_chunk.zero_grad_buffer()
         optim.zero_grad()
-        forward_backward_no_pipelining(
-            forward_step_func=functools.partial(forward_step_func, device),
-            data_iterator=train_iterator,
-            model=model,
-            num_microbatches=gradient_accumulation,
-            seq_length=4096,
-            micro_batch_size=micro_batch_size,
-            forward_only=False,
-        )
+        if pp_size > 1 and virtual_pipeline_model_parallel_size is not None:
+            forward_backward_pipelining_with_interleaving(
+                forward_step_func=functools.partial(forward_step_func, device),
+                data_iterator=train_iterator,
+                model=model,
+                num_microbatches=num_microbatches,
+                seq_length=4096,
+                micro_batch_size=micro_batch_size,
+                forward_only=False,
+            )
+        elif pp_size > 1:
+            forward_backward_pipelining_without_interleaving(
+                forward_step_func=functools.partial(forward_step_func, device),
+                data_iterator=train_iterator,
+                model=model,
+                num_microbatches=num_microbatches,
+                seq_length=4096,
+                micro_batch_size=micro_batch_size,
+                forward_only=False,
+            )
+        else:
+            forward_backward_no_pipelining(
+                forward_step_func=functools.partial(forward_step_func, device),
+                data_iterator=train_iterator,
+                model=model,
+                num_microbatches=num_microbatches,
+                seq_length=4096,
+                micro_batch_size=micro_batch_size,
+                forward_only=False,
+            )
         optim.step()
         torch.cuda.synchronize()
         end, end_wall = time_pair()
@@ -258,6 +352,8 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--tensor_parallel_size", type=int, default=4)
+    parser.add_argument("--pipeline_model_parallel_size", type=int, default=1)
+    parser.add_argument("--virtual_pipeline_model_parallel_size", type=int, default=None)
     parser.add_argument("--num_layers", type=int, default=32)
     parser.add_argument("--hidden_size", type=int, default=4096)
     parser.add_argument("--ffn_hidden_size", type=int, default=11008)
@@ -272,6 +368,8 @@ if __name__ == "__main__":
     enable_function_tracer()
     main(
         tensor_parallel_size=args.tensor_parallel_size,
+        pipeline_model_parallel_size=args.pipeline_model_parallel_size,
+        virtual_pipeline_model_parallel_size=args.virtual_pipeline_model_parallel_size,
         num_layers=args.num_layers,
         hidden_size=args.hidden_size,
         ffn_hidden_size=args.ffn_hidden_size,


### PR DESCRIPTION
## Summary

- NCCL point-to-point send/recv simulation with both ungrouped and grouped (ncclGroupStart/End) paths
- CUPTI extended from kernel-only to kernel+memcpy+memset activity timing, with CUPTI API version compatibility
- Torch op estimation for masked_fill, dropout, gelu, and sum variants
- Event queue priority update bug fix
- Pipeline parallel and virtual pipeline support in Megatron test

---

## P2P Implementation

### Architecture Overview

P2P simulation uses a FIFO matching queue keyed by `(comm_id, sender_rank, receiver_rank)` to preserve NCCL's peer ordering for repeated sends/receives. Each P2P endpoint creates an `unmatched_barrier` (a `None`-sentinel event) that holds the endpoint's stream until the matching peer arrives, and `flow_start`/`flow_end` events that gate the actual network transfer.

When both sides of a P2P pair are present, `schedule_p2p_flow` creates a `netsim::Flow` between the two hosts and inserts it as an `Action::Communication` node in the event DAG. Both sides' `flow_end` events depend on this communication node, so downstream stream work is gated by transfer completion. The transfer starts at `max(send.curr_time, recv.curr_time)` — if the receiver calls `ncclRecv` before the sender is ready, the receiver's stream shows an idle gap equal to the sender's compute time. This gap is the pipeline bubble captured in the simulated timeline.

### Ungrouped P2P

Each `ncclSend`/`ncclRecv` is intercepted individually by the stub (`stub/nccl.c`) and forwarded to the simulator as `CudaCall::NcclSend` or `CudaCall::NcclRecv`. The flow endpoints are created with `add_event`, making them **stream-visible events** — the CUDA stream is fully occupied until the matched network flow completes. Consequently, any additional P2P calls on the same stream are serialized behind the currently unmatched send/recv.

```
Stream DAG per endpoint:
  [unmatched_barrier] → flow_start → flow_end → (following stream work)
                              ↑            ↑
                              │     gated by flow_event once matched
                              │
                        waits for peer
```

### Grouped P2P (ncclGroupStart/End)

`NcclCaller` in `capi.rs` buffers all NCCL calls between `ncclGroupStart` and `ncclGroupEnd`. At group end, P2P calls (`NcclSend`/`NcclRecv`) are separated from other calls and batched into a single `NcclP2pGroup` sent to the simulator. Non-P2P calls (comm init, collectives) are dispatched individually as before.

The simulator models grouped P2P with a fundamentally different DAG structure from ungrouped:

- **Per-stream group shell**: A `group_start` and `group_end` event pair is created as stream-visible events. `group_start` depends on a `group_barrier` that prevents internal flow points from firing during DAG construction. `group_end` depends on every internal `flow_end`, so following stream work advances only after all transfers in the group finish.

- **Individual flows are off-stream**: Each P2P call within the group creates `flow_start`/`flow_end` points via `add_action_or_point` (raw DAG points, not stream events). Each flow's `flow_start` depends on both the `group_start` and its own `unmatched_barrier`. This means flow A can be matched and scheduled while flow B is still waiting for its peer — internal flows run **concurrently** rather than being serialized by CUDA stream order.

```
Group DAG per stream:
  group_barrier
       │
  group_start (stream-visible)
       │
       ├── flow_A_start ── flow_A_end ──┐
       │       │                         │
       │  [unmatched_A]                  │
       │                                 │
       ├── flow_B_start ── flow_B_end ──┤
       │       │                         │
       │  [unmatched_B]                  │
       │                                 │
  group_end (stream-visible) ←──────────┘
       │
  (following stream work)
```

**Key difference**: Ungrouped P2P serializes sends/recvs on the stream — each call blocks until its peer arrives and the transfer completes. Grouped P2P allows all calls in the group to proceed concurrently; the stream only blocks at `group_end` until every transfer finishes.

---

## CUPTI Activity Timing

### Motivation

`cudaEventElapsedTime` measures wall-clock time between GPU stream events, which includes host-side kernel launch and dispatch overhead (~20-30% on tiny models). CUPTI Activity API captures GPU-clock timestamps recorded by the driver when operations actually start and end on the device.

### Changes

- **Extended activity tracking**: Previously tracked only `CONCURRENT_KERNEL` activity. Now also enables `MEMCPY`, `MEMCPY2` (peer-to-peer), and `MEMSET` activity kinds, providing a more complete picture of GPU activity time.
- **CUPTI API version compatibility**: `Memcpy` record structs changed between CUPTI API versions (Memcpy5 → Memcpy6 at API version 130). The shim uses `#if CUPTI_API_VERSION >= 130000` to select the correct struct type.
- **Defensive time accumulation**: `add_activity_duration` guards against `(0, 0)` timestamp pairs (uninitialized records) and negative durations.
- **Renames**: `g_kernel_ns` → `g_activity_ns`, `sum_kernel_ns` → `sum_activity_ns` to reflect the broader scope.

---

## Torch Op Support

Added estimation support for operations needed by Megatron pipeline parallel workloads:

| Op | Variants |
|----|----------|
| masked_fill | `aten::masked_fill`, `aten::masked_fill_` |
| dropout | `aten::dropout`, `aten::native_dropout`, `aten::native_dropout_backward`, `aten::_fused_dropout` |
| gelu | `aten::gelu`, `aten::gelu_backward` |
| sum | `aten::sum` |

Duration estimation mirrors the real op semantics: dropout probability is passed through as integer millionths to match PyTorch's internal representation; `_fused_dropout` invokes the cuDNN fused path (`internal_fused_dropout`).

---

## Bug Fix

`event_queue.rs`: `change_priority_by` was reading `started_record.start_time` after it had already been set to `new_start_time`, so the priority delta was always zero. Now captures the delta before updating the start time.

---

## Megatron Test

`test_megatron.py` now supports pipeline parallel and virtual pipeline configurations:
- `--pipeline_model_parallel_size` and `--virtual_pipeline_model_parallel_size` CLI args
- Interleaved (`forward_backward_pipelining_with_interleaving`) and non-interleaved schedules
- Virtual pipeline stage construction with `pre_process`/`post_process` boundary flags
- Micro-batch count scaled to `max(gradient_accumulation, pp_size * 4)` for pipeline configs
