### PR TITLE
stub: add nvmlSystemGetCudaDriverVersion_v2

### DIFF
--- a/stub/nvml.c
+++ b/stub/nvml.c
@@ -7,6 +7,18 @@ nvmlInit_v2(void)
     return NVML_SUCCESS;
 }
 
+// PyTorch 2.9.1's c10::cuda::DriverAPI (driver_api.cpp) looks up this symbol
+// during BF16 cast and aborts with INTERNAL ASSERT FAILED if it's missing.
+// Match the version reported by cudaDriverGetVersion / cudaRuntimeGetVersion.
+nvmlReturn_t
+nvmlSystemGetCudaDriverVersion_v2(int* cudaDriverVersion)
+{
+    if (cudaDriverVersion == NULL)
+        return NVML_ERROR_INVALID_ARGUMENT;
+    *cudaDriverVersion = 12080;
+    return NVML_SUCCESS;
+}
+
 nvmlReturn_t
 nvmlDeviceGetHandleByPciBusId_v2(const char* pciBusId, nvmlDevice_t* device)
 {


### PR DESCRIPTION
PyTorch 2.9.1's c10::cuda::DriverAPI (driver_api.cpp) looks up this NVML symbol during ops like BF16 cast and aborts with INTERNAL ASSERT FAILED if it's not exported by libcuda.so. The existing stub/nvml.c ships 5 symbols but not this one; PyTorch only began calling it in a version >= 2.9.

Return version 12080 to match what cudaDriverGetVersion and cudaRuntimeGetVersion already report in stub/cudart.c.