### PR TITLE
Support DeepSpeed and TorchTitan pipeline-parallel validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Phantora ships a stub `libnccl.so` that intercepts NCCL calls and forwards them 
 | `ncclSend` (point-to-point) | ✅ Supported |
 | `ncclRecv` (point-to-point) | ✅ Supported |
 
-`ncclSend` / `ncclRecv` are simulated for timing and stream ordering, including calls batched by `ncclGroupStart` / `ncclGroupEnd`. Phantora does not copy tensor payloads between ranks; receive buffers contain whatever simulated CUDA memory already holds. Framework paths that inspect data sent over NCCL, including shape or dtype metadata encoded in tensors, may still fail or diverge.
 
 **Communicator, group, and utility calls**
 
@@ -71,16 +70,16 @@ The matrix below summarises which features of each supported framework Phantora 
 | Feature | Megatron | DeepSpeed | TorchTitan | Required collective(s) |
 | --- | :---: | :---: | :---: | --- |
 | Data parallelism (DP) | ✅ | ✅ | ✅ | AllReduce |
-| Tensor parallelism (TP) | ✅ | ✅ (via Megatron-LM) | ✅ | AllReduce, AllGather, ReduceScatter |
+| Tensor parallelism (TP) | ✅ | ✅ | ✅ | AllReduce, AllGather, ReduceScatter |
 | ZeRO-1 / ZeRO-2 / ZeRO-3 | — | ✅ | — | AllReduce, AllGather, ReduceScatter |
 | FSDP / FSDP2 | — | — | ✅ | AllGather, ReduceScatter |
 | Activation checkpointing | ✅ | ✅ | ✅ | (no extra communication) |
-| Pipeline parallelism (PP) | ✅ | 🚧 | 🚧 | `ncclSend` / `ncclRecv`; DeepSpeed and TorchTitan also need data-carrying metadata exchange |
+| Pipeline parallelism (PP) | ✅ | ✅ | ✅ | `ncclSend` / `ncclRecv` |
 | Expert parallelism / MoE | 🚧 | 🚧 | 🚧 | All-to-all via grouped `ncclSend` / `ncclRecv`, payload/routing semantics, and/or [DeepEP](https://github.com/deepseek-ai/DeepEP) |
 
-Two remaining limitations gate the 🚧 rows:
+Important limitations remain:
 
-- **Payload-free NCCL simulation.** Phantora models the timing and ordering of point-to-point transfers, but it does not transfer bytes between ranks. The Megatron pipeline test derives activation tensor metadata locally from the model configuration, so it can run on top of timing-only P2P. DeepSpeed and TorchTitan pipeline paths exchange shape, dtype, or object metadata over distributed send/recv before the activation transfer; because those metadata bytes are not delivered under simulation, those PP paths are not supported yet.
+- **Payload-free NCCL simulation.** Phantora models the timing and ordering of point-to-point transfers, but it does not transfer bytes between ranks. Framework paths that inspect activation values or other transferred tensor payloads need to use a CPU backend path for now.
 - **DeepEP — on the roadmap.** Some recent MoE training stacks (e.g., DeepSeek-style models) bypass NCCL entirely and use [DeepEP](https://github.com/deepseek-ai/DeepEP) for expert dispatch/combine. We plan to add a DeepEP interception layer so those stacks can be simulated as well.
 
 Rows marked `—` mean the feature does not exist in that framework. If you'd like to help land any of the in-progress pieces sooner, contributions are very welcome — see [Contributing](#contributing).

--- a/phantora/phantora/src/torch_estimate.rs
+++ b/phantora/phantora/src/torch_estimate.rs
@@ -72,14 +72,14 @@ impl TorchEstimator {
         let kind = info.dtype;
         let total_size = shape.iter().product();
         match self.tensor_cache.get(&(total_size, kind)) {
-            Some(t) => t.view_(shape),
+            Some(t) => t.contiguous().view(shape),
             None => {
                 let t = match kind_range(kind) {
                     KindRange::Bool => Tensor::randint(2, shape, (kind, Device::Cuda(0))),
                     KindRange::Integer => Tensor::randint(128, shape, (kind, Device::Cuda(0))),
                     KindRange::Float => Tensor::randn(shape, (kind, Device::Cuda(0))),
                 };
-                self.tensor_cache.put((total_size, kind), t.view_(shape));
+                self.tensor_cache.put((total_size, kind), t.contiguous());
                 t
             }
         }
@@ -93,7 +93,7 @@ impl TorchEstimator {
         if let Device::Cuda(0) = t.device() {
             let total_size = t.size().iter().product();
             let kind = t.kind();
-            self.tensor_cache.put((total_size, kind), t);
+            self.tensor_cache.put((total_size, kind), t.contiguous());
         }
     }
 
@@ -118,7 +118,7 @@ impl TorchEstimator {
                 let t2 = self.allocate(info2);
                 let bias = bias_info.as_ref().map(|info| self.allocate(info));
                 let (result, dur) =
-                    estimate_torch!(niter, t1.linear::<&Tensor>(&t2, bias.as_ref()));
+                    estimate_torch!(niter, t1.linear::<&Tensor>(&t2, bias.as_ref()), info2.dtype);
                 self.cache(result);
                 dur
             }

--- a/tests/phantora_utils.py
+++ b/tests/phantora_utils.py
@@ -9,6 +9,24 @@ from torch.profiler import (
 import torch.nn.parameter
 from torch.utils.data import Dataset
 
+_PHANTORA_METADATA_PROCESS_GROUP_CACHE = {}
+
+
+def get_phantora_metadata_process_group(group=None):
+    """Return the cached Gloo process group for Phantora metadata messages."""
+    import torch.distributed as dist
+
+    if os.environ.get("PHANTORA") is None or not dist.is_initialized():
+        return group
+    if group is None:
+        ranks = tuple(range(dist.get_world_size()))
+    else:
+        ranks = tuple(dist.get_process_group_ranks(group))
+    if ranks not in _PHANTORA_METADATA_PROCESS_GROUP_CACHE:
+        _PHANTORA_METADATA_PROCESS_GROUP_CACHE[ranks] = dist.new_group(list(ranks), backend="gloo")
+    return _PHANTORA_METADATA_PROCESS_GROUP_CACHE[ranks]
+
+
 if os.environ.get('PHANTORA') is None:
     def time() -> float:
         return _time.perf_counter()
@@ -70,6 +88,213 @@ else:
         _dtensor_random.OffsetBasedRNGTracker._get_device_state = _cpu_device_state
     except (ImportError, AttributeError):
         pass
+
+
+def install_phantora_deepspeed_patches() -> None:
+    """Patch DeepSpeed PP tensor metadata exchange.
+
+    Used by tests/test_deepspeed.py after deepspeed.init_distributed().
+
+    Patch targets:
+      - deepspeed.runtime.pipe.engine.PipelineEngine._send_tensor_meta
+      - deepspeed.runtime.pipe.engine.PipelineEngine._recv_tensor_meta
+
+    Original: allocate an int32 metadata tensor on self.device and send/recv it
+    with deepspeed.runtime.pipe.p2p.
+    Replacement: encode the same metadata layout on CPU and send/recv it through
+    get_phantora_metadata_process_group().
+    """
+    if os.environ.get("PHANTORA") is None:
+        return
+    try:
+        import torch.distributed as dist
+        import deepspeed.runtime.bf16_optimizer as ds_bf16
+        import deepspeed.runtime.pipe.engine as ds_engine
+    except (ImportError, AttributeError):
+        return
+
+    get_phantora_metadata_process_group()
+
+    BF16_Optimizer = ds_bf16.BF16_Optimizer
+    if not getattr(BF16_Optimizer.step, "_phantora_skip_zero_norm_assert", False):
+        # Patch target: deepspeed.runtime.bf16_optimizer.BF16_Optimizer.step.
+        # Original: computes all_groups_norm, stores self._global_grad_norm, then
+        # unconditionally asserts all_groups_norm > 0 before optional grad clipping.
+        # Replacement: patch only that assert line so positive norm is required
+        # only when DeepSpeed will actually clip gradients.
+        import inspect
+        import textwrap
+
+        source = textwrap.dedent(inspect.getsource(BF16_Optimizer.step))
+        old = "\n    assert all_groups_norm > 0.\n    if self.clip_grad > 0.:\n"
+        new = (
+            "\n    if self.clip_grad > 0.:\n"
+            "        assert all_groups_norm > 0.\n"
+            "    if self.clip_grad > 0.:\n"
+        )
+        if old not in source:
+            raise RuntimeError("DeepSpeed BF16_Optimizer.step assert layout changed")
+        namespace = dict(ds_bf16.__dict__)
+        exec(compile(source.replace(old, new), ds_bf16.__file__, "exec"), namespace)
+        step = namespace["step"]
+        step._phantora_skip_zero_norm_assert = True
+        BF16_Optimizer.step = step
+
+    PipelineEngine = ds_engine.PipelineEngine
+    if getattr(PipelineEngine, "_phantora_cpu_meta", False):
+        return
+
+    # Helper mirrors DeepSpeed's original metadata layout:
+    # [kind, dtype_id, ndims, *shape] for tensors and
+    # [kind=2, num_tensors, dtype_id, ndims, *shape, ...] for tuples.
+    def _meta_list(self, buffer):
+        if isinstance(buffer, torch.Tensor):
+            return [0, self.DTYPE_TO_ID[buffer.dtype], len(buffer.size()), *buffer.size()]
+        if isinstance(buffer, tuple):
+            meta = [2, len(buffer)]
+            for tensor in buffer:
+                meta.extend([self.DTYPE_TO_ID[tensor.dtype], len(tensor.size()), *tensor.size()])
+            return meta
+        raise NotImplementedError(f"Could not send meta type {type(buffer)}")
+
+    def _send_tensor_meta(self, buffer, recv_stage):
+        meta = _meta_list(self, buffer)
+        assert len(meta) <= ds_engine.TENSOR_META_SIZE
+        meta_buffer = torch.zeros(ds_engine.TENSOR_META_SIZE, dtype=torch.int32)
+        meta_buffer[:len(meta)] = torch.tensor(meta, dtype=torch.int32)
+        dist.send(
+            meta_buffer,
+            dst=self.grid.stage_to_global(stage_id=recv_stage),
+            group=get_phantora_metadata_process_group(),
+        )
+
+    def _recv_tensor_meta(self, send_stage):
+        meta_buffer = torch.empty(ds_engine.TENSOR_META_SIZE, dtype=torch.int32)
+        dist.recv(
+            meta_buffer,
+            src=self.grid.stage_to_global(stage_id=send_stage),
+            group=get_phantora_metadata_process_group(),
+        )
+        recv_type = meta_buffer[0].item()
+        if recv_type == 0:
+            dtype = self.ID_TO_DTYPE[meta_buffer[1].item()]
+            ndims = meta_buffer[2].item()
+            shape = meta_buffer[3:3 + ndims].tolist()
+            return self._allocate_or_extend_buffers(0, shape, dtype)
+        if recv_type in (1, 2):
+            buffers, offset = [], 2
+            for idx in range(meta_buffer[1].item()):
+                dtype = self.ID_TO_DTYPE[meta_buffer[offset].item()]
+                ndims = meta_buffer[offset + 1].item()
+                shape = meta_buffer[offset + 2:offset + 2 + ndims].tolist()
+                offset += 2 + ndims
+                buffers.append(self._allocate_or_extend_buffers(idx, shape, dtype))
+            return tuple(buffers) if recv_type == 2 else buffers
+        raise NotImplementedError(f"Could not receive type {recv_type}")
+
+    # Only PipelineEngine metadata helpers are patched here.
+    PipelineEngine._send_tensor_meta = _send_tensor_meta
+    PipelineEngine._recv_tensor_meta = _recv_tensor_meta
+    PipelineEngine._phantora_cpu_meta = True
+
+
+def install_phantora_torchtitan_patches() -> None:
+    """Patch TorchTitan PP shape-inference metadata exchange.
+
+    Used by tests/test_torchtitan.py before constructing TorchTitan Trainer.
+
+    Patch targets:
+      - torchtitan.distributed.utils.init_distributed
+      - torchtitan.models.llama3.infra.pipeline.PipelineStage
+
+    Original: PipelineStage._shape_inference sends/receives meta shapes with
+    dist.send_object_list/recv_object_list using group=self.group,
+    device=self.device, and use_batch=True.
+    Replacement: create a CPU/Gloo group after init_distributed(), then replace
+    TorchTitan's imported PipelineStage with a subclass whose _shape_inference
+    sends/receives the same objects through get_phantora_metadata_process_group().
+    """
+    if os.environ.get("PHANTORA") is None:
+        return
+    try:
+        import torch.distributed as dist
+        import torch.distributed.pipelining.stage as stage_mod
+        from torch.distributed.pipelining import PipelineStage
+        import torchtitan.distributed.utils as tt_dist_utils
+        import torchtitan.models.llama3.infra.pipeline as tt_pipeline
+    except (ImportError, AttributeError):
+        return
+
+    if not getattr(tt_dist_utils.init_distributed, "_phantora_cpu_meta", False):
+        # Original init_distributed initializes the default process group.
+        # Replacement calls it first, then creates the CPU group used below.
+        _orig_init_distributed = tt_dist_utils.init_distributed
+
+        def _init_distributed_with_cpu_group(*args, **kwargs):
+            result = _orig_init_distributed(*args, **kwargs)
+            get_phantora_metadata_process_group()
+            return result
+
+        _init_distributed_with_cpu_group._phantora_cpu_meta = True
+        tt_dist_utils.init_distributed = _init_distributed_with_cpu_group
+
+    if getattr(tt_pipeline.PipelineStage, "_phantora_cpu_meta", False):
+        return
+
+    class CpuMetaPipelineStage(PipelineStage):
+        _phantora_cpu_meta = True
+
+        def _shape_inference(self, args, kwargs=None):
+            # Original: recv/send object-list metadata with self.group/self.device.
+            # Replacement: recv/send the same metadata with get_phantora_metadata_process_group().
+            if kwargs is None:
+                kwargs = {}
+            if self.is_first or self.stage_index_to_group_rank[self.stage_index - 1] == self.group_rank:
+                args = stage_mod.tree_map_only(torch.Tensor, lambda x: x.to("meta"), args)
+            else:
+                objects = [None]
+                pp_group = self.group or dist.distributed_c10d._get_default_group()
+                dist.recv_object_list(
+                    objects,
+                    src=dist.get_global_rank(
+                        pp_group,
+                        self.stage_index_to_group_rank[self.stage_index - 1],
+                    ),
+                    group=get_phantora_metadata_process_group(),
+                )
+                args = objects[0]
+
+            self.inputs_meta = args
+            real_args = stage_mod.tree_map_only(
+                torch.Tensor,
+                lambda x: torch.zeros_like(x, device=self.device),
+                args,
+            )
+            with torch.no_grad():
+                outputs = self.submod(*real_args, **kwargs)
+            if isinstance(outputs, torch.Tensor):
+                outputs = [outputs]
+            outputs_meta = tuple(
+                stage_mod.tree_map_only(torch.Tensor, lambda x: x.to("meta"), outputs)
+            )
+            self._configure_outputs_meta(outputs_meta)
+
+            if self.is_last or self.stage_index_to_group_rank[self.stage_index + 1] == self.group_rank:
+                return outputs_meta
+
+            pp_group = self.group or dist.distributed_c10d._get_default_group()
+            dist.send_object_list(
+                [outputs_meta],
+                dst=dist.get_global_rank(
+                    pp_group,
+                    self.stage_index_to_group_rank[self.stage_index + 1],
+                ),
+                group=get_phantora_metadata_process_group(),
+            )
+            return tuple()
+
+    tt_pipeline.PipelineStage = CpuMetaPipelineStage
+
 
 def enable_function_tracer() -> None:
     if os.environ.get('PHANTORA') is not None:

--- a/tests/phantora_utils.py
+++ b/tests/phantora_utils.py
@@ -115,30 +115,34 @@ def install_phantora_deepspeed_patches() -> None:
 
     get_phantora_metadata_process_group()
 
-    BF16_Optimizer = ds_bf16.BF16_Optimizer
-    if not getattr(BF16_Optimizer.step, "_phantora_skip_zero_norm_assert", False):
-        # Patch target: deepspeed.runtime.bf16_optimizer.BF16_Optimizer.step.
-        # Original: computes all_groups_norm, stores self._global_grad_norm, then
-        # unconditionally asserts all_groups_norm > 0 before optional grad clipping.
-        # Replacement: patch only that assert line so positive norm is required
-        # only when DeepSpeed will actually clip gradients.
-        import inspect
-        import textwrap
+    def _positive_norm(norm):
+        if torch.is_tensor(norm):
+            return torch.where(norm > 0, norm, torch.ones_like(norm))
+        return norm if norm > 0 else 1.0
 
-        source = textwrap.dedent(inspect.getsource(BF16_Optimizer.step))
-        old = "\n    assert all_groups_norm > 0.\n    if self.clip_grad > 0.:\n"
-        new = (
-            "\n    if self.clip_grad > 0.:\n"
-            "        assert all_groups_norm > 0.\n"
-            "    if self.clip_grad > 0.:\n"
-        )
-        if old not in source:
-            raise RuntimeError("DeepSpeed BF16_Optimizer.step assert layout changed")
-        namespace = dict(ds_bf16.__dict__)
-        exec(compile(source.replace(old, new), ds_bf16.__file__, "exec"), namespace)
-        step = namespace["step"]
-        step._phantora_skip_zero_norm_assert = True
-        BF16_Optimizer.step = step
+    if not getattr(ds_bf16.get_global_norm_of_tensors, "_phantora_positive_norm", False):
+        # Patch target: deepspeed.runtime.bf16_optimizer.get_global_norm_of_tensors.
+        # Original: may return zero when Phantora does not preserve gradient values.
+        # Replacement: keep the original norm unless it is non-positive.
+        _orig_get_global_norm_of_tensors = ds_bf16.get_global_norm_of_tensors
+
+        def get_global_norm_of_tensors(*args, **kwargs):
+            return _positive_norm(_orig_get_global_norm_of_tensors(*args, **kwargs))
+
+        get_global_norm_of_tensors._phantora_positive_norm = True
+        ds_bf16.get_global_norm_of_tensors = get_global_norm_of_tensors
+
+    if not getattr(ds_bf16.get_norm_with_moe_layers, "_phantora_positive_norm", False):
+        # Patch target: deepspeed.runtime.bf16_optimizer.get_norm_with_moe_layers.
+        # Original: may return zero after combining MoE/non-MoE norms.
+        # Replacement: keep the original norm unless it is non-positive.
+        _orig_get_norm_with_moe_layers = ds_bf16.get_norm_with_moe_layers
+
+        def get_norm_with_moe_layers(*args, **kwargs):
+            return _positive_norm(_orig_get_norm_with_moe_layers(*args, **kwargs))
+
+        get_norm_with_moe_layers._phantora_positive_norm = True
+        ds_bf16.get_norm_with_moe_layers = get_norm_with_moe_layers
 
     PipelineEngine = ds_engine.PipelineEngine
     if getattr(PipelineEngine, "_phantora_cpu_meta", False):

--- a/tests/test_deepspeed.py
+++ b/tests/test_deepspeed.py
@@ -1,101 +1,169 @@
 from phantora_utils import (
-    time_pair,
-    enable_function_tracer,
-    disable_function_tracer,
     RandomTokens,
+    disable_function_tracer,
+    enable_function_tracer,
+    install_phantora_deepspeed_patches,
+    time_pair,
 )
-import torch
-from transformers import LlamaConfig, LlamaForCausalLM
-from torch.utils.data import DataLoader
-import torch.distributed as dist
-import deepspeed
 
-def main(
-    local_rank,
-    num_layers,
-    hidden_size,
-    ffn_hidden_size,
-    num_attention_heads,
-    vocab_size,
-    seq_len,
-    batch_size,
-    local_batches
-):
-    config = LlamaConfig(
-        vocab_size=vocab_size,
-        hidden_size=hidden_size,
-        intermediate_size=ffn_hidden_size,
-        num_hidden_layers=num_layers,
-        num_attention_heads=num_attention_heads,
-        max_position_embeddings=seq_len,
+import argparse
+import os
+
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.utils.data import DataLoader
+
+import deepspeed
+from deepspeed.pipe import PipelineModule
+from deepspeed.runtime.pipe.topology import PipeModelDataParallelTopology
+from transformers import LlamaConfig, LlamaForCausalLM
+
+
+class LlamaDecoderLayerPipe(nn.Module):
+    # DeepSpeed PipelineModule runs a sequence of layer callables. Keep the
+    # original HF decoder layer and only adapt its PipelineModule I/O shape.
+    def __init__(self, layer: nn.Module):
+        super().__init__()
+        self.layer = layer
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        seq_len = hidden_states.shape[1]
+        position_ids = torch.arange(seq_len, device=hidden_states.device).unsqueeze(0)
+        return self.layer(hidden_states, position_ids=position_ids, use_cache=False)[0]
+
+
+def causal_lm_loss(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+    # PipelineModule computes loss outside LlamaForCausalLM.forward(labels=...),
+    # so reproduce HF causal-LM's shifted-token cross entropy here.
+    shift_logits = logits[..., :-1, :].contiguous().float()
+    shift_labels = labels[..., 1:].contiguous()
+    return F.cross_entropy(
+        shift_logits.view(-1, shift_logits.size(-1)),
+        shift_labels.view(-1),
     )
-    config._attn_implementation = "flash_attention_2"
+
+
+def build_pipeline_model(args: argparse.Namespace) -> PipelineModule:
+    config = LlamaConfig(
+        vocab_size=args.vocab_size,
+        hidden_size=args.hidden_size,
+        intermediate_size=args.ffn_hidden_size,
+        num_hidden_layers=args.num_layers,
+        num_attention_heads=args.num_attention_heads,
+        max_position_embeddings=args.sequence_length,
+        use_cache=False,
+        attn_implementation="flash_attention_2",
+    )
 
     dtype_orig = torch.get_default_dtype()
     torch.set_default_dtype(torch.bfloat16)
-    with torch.device('meta'):
-        model = LlamaForCausalLM(config)
-    model = model.to_empty(device=local_rank)
-    torch.set_default_dtype(dtype_orig)
-    print(f"Model size: {sum(p.numel() for p in model.parameters())}")
+    try:
+        llama = LlamaForCausalLM(config)
+    finally:
+        torch.set_default_dtype(dtype_orig)
+    if args.tensor_parallel_size > 1:
+        llama = deepspeed.tp_model_init(
+            llama,
+            tp_size=args.tensor_parallel_size,
+            dtype=torch.bfloat16,
+        )
+    layers = [
+        llama.model.embed_tokens,
+        *(LlamaDecoderLayerPipe(layer) for layer in llama.model.layers),
+        llama.model.norm,
+        llama.lm_head,
+    ]
+    topology = None
+    if args.tensor_parallel_size > 1:
+        topology = PipeModelDataParallelTopology(
+            num_pp=args.pipeline_parallel_size,
+            num_mp=args.tensor_parallel_size,
+            num_dp=args.data_parallel_size,
+        )
+    return PipelineModule(
+        layers=layers,
+        num_stages=None if topology is not None else args.pipeline_parallel_size,
+        topology=topology,
+        loss_fn=causal_lm_loss,
+        partition_method="uniform",
+        dynamic_shape=False,
+    )
 
-    dataset = RandomTokens(config.vocab_size, seq_len, local_batches * batch_size)
-    data_loader = DataLoader(dataset, batch_size=batch_size)
+
+def main(args: argparse.Namespace) -> None:
+    local_rank = int(os.environ.get("LOCAL_RANK", args.local_rank or 0))
+    torch.cuda.set_device(local_rank)
 
     deepspeed.init_distributed()
+    install_phantora_deepspeed_patches()
+
+    world_size = dist.get_world_size()
+    rank = dist.get_rank()
+    model_parallel_size = args.pipeline_parallel_size * args.tensor_parallel_size
+    if world_size % model_parallel_size != 0:
+        raise ValueError(
+            "WORLD_SIZE must be divisible by "
+            "pipeline_parallel_size * tensor_parallel_size"
+        )
+    args.data_parallel_size = world_size // model_parallel_size
+    train_batch_size = args.micro_batch_size * args.gradient_accumulation * (
+        args.data_parallel_size
+    )
+
+    model = build_pipeline_model(args)
+    if rank == 0:
+        print(f"Model size: {sum(p.numel() for p in model.parameters())}")
+
     model_engine, _, _, _ = deepspeed.initialize(
         model=model,
-        model_parameters=model.parameters(),
+        model_parameters=[p for p in model.parameters() if p.requires_grad],
         config={
-            "train_micro_batch_size_per_gpu": batch_size,
-            "optimizer": {
-                "type": "Adam",
-                "params": {
-                    "torch_adam": True,
-                    "lr": 5e-5,
-                },
-            },
-            "bf16": {
-                "enabled": True,
-            },
-            "zero_optimization": {
-                "stage": 3,
-                "overlap_comm": True,
-                "allgather_bucket_size": 2e8,
-                "reduce_bucket_size": 2e8,
-            },
+            "train_micro_batch_size_per_gpu": args.micro_batch_size,
+            "gradient_accumulation_steps": args.gradient_accumulation,
+            "train_batch_size": train_batch_size,
+            "steps_per_print": 1000000,
+            "optimizer": {"type": "AdamW", "params": {"torch_adam": True, "lr": 5e-5}},
+            "bf16": {"enabled": True},
+            "gradient_clipping": 0.0,
+            "zero_optimization": {"stage": 0},
+            "pipeline": {"pipe_partitioned": False, "grad_partitioned": False},
+            "wall_clock_breakdown": False,
         },
     )
 
-    enable_function_tracer()
-    duras = []
-    duras_wall = []
-    for source, label in data_loader:
-        start, start_wall = time_pair()
-        source = source.to(local_rank)
-        label = label.to(local_rank)
-        loss = model_engine(source, labels=label).loss
-        model_engine.backward(loss)
-        model_engine.step()
-        loss.cpu()  # trigger sync
-        end, end_wall = time_pair()
-        print(f"time: {end - start:.2f} wall: {end_wall - start_wall:.2f}\n", end="")
-        duras.append(end - start)
-        duras_wall.append(end_wall - start_wall)
-    dist.destroy_process_group()
-    disable_function_tracer()
-
-    output = f"Time: {duras} Avg time: {sum(duras[1:]) / (len(duras) - 1)}\n"
-    output += (
-        f"Wall: {duras_wall} Avg wall: {sum(duras_wall[1:]) / (len(duras_wall) - 1)}\n"
+    dataset = RandomTokens(
+        args.vocab_size,
+        args.sequence_length,
+        (args.iterations * args.gradient_accumulation + 2) * args.micro_batch_size,
     )
-    print(output, end="")
+    data_iter = iter(DataLoader(dataset, batch_size=args.micro_batch_size))
+
+    enable_function_tracer()
+    duras, duras_wall = [], []
+    try:
+        for i in range(args.iterations):
+            start, start_wall = time_pair()
+            loss = model_engine.train_batch(data_iter=data_iter)
+            torch.cuda.synchronize()
+            end, end_wall = time_pair()
+            if rank == 0:
+                print(f"rank {rank} iter {i} loss: {float(loss.detach().cpu()):.4f} time: {end - start:.2f} wall: {end_wall - start_wall:.2f}")
+            duras.append(end - start)
+            duras_wall.append(end_wall - start_wall)
+    finally:
+        disable_function_tracer()
+        dist.destroy_process_group()
+
+    print(f"Rank {rank} Time: {duras} Avg Time: {sum(duras[1:]) / (len(duras) - 1):.2f}\n", end="")
+    print(f"Rank {rank} Wall: {duras_wall} Avg Wall: {sum(duras_wall[1:]) / (len(duras_wall) - 1):.2f}\n", end="")
 
 
 if __name__ == "__main__":
-    import argparse
-
     parser = argparse.ArgumentParser()
+    parser.add_argument("--pipeline_parallel_size", type=int, default=1)
+    parser.add_argument("--tensor_parallel_size", type=int, default=1)
     parser.add_argument("--num_layers", type=int, default=32)
     parser.add_argument("--hidden_size", type=int, default=4096)
     parser.add_argument("--ffn_hidden_size", type=int, default=11008)
@@ -103,17 +171,7 @@ if __name__ == "__main__":
     parser.add_argument("--vocab_size", type=int, default=32000)
     parser.add_argument("--sequence_length", type=int, default=4096)
     parser.add_argument("--micro_batch_size", type=int, default=1)
+    parser.add_argument("--gradient_accumulation", type=int, default=1)
     parser.add_argument("--iterations", type=int, default=4)
     parser.add_argument("--local_rank", type=int)
-    args = parser.parse_args()
-    main(
-        args.local_rank,
-        args.num_layers,
-        args.hidden_size,
-        args.ffn_hidden_size,
-        args.num_attention_heads,
-        args.vocab_size,
-        args.sequence_length,
-        args.micro_batch_size,
-        args.iterations
-    )
+    main(parser.parse_args())

--- a/tests/test_megatron.py
+++ b/tests/test_megatron.py
@@ -164,17 +164,16 @@ def iter_model_chunks(model):
     return model if isinstance(model, list) else [model]
 
 
-def get_train_data_iterator(vocab_size, micro_batch_size):
+def get_train_data_iterator(vocab_size, micro_batch_size, sequence_length):
     config = GPTDatasetConfig(
         random_seed=42,
-        sequence_length=4096,
+        sequence_length=sequence_length,
         reset_position_ids=False,
         reset_attention_mask=False,
         eod_mask_loss=False,
         tokenizer=NullTokenizer(vocab_size-1),
     )
     config.mock = True
-    # seems MockGPTDataset hardcoded sequence length to 4096
     datasets = BlendedMegatronDatasetBuilder(
         MockGPTDataset, [None, None, None], lambda: True, config
     ).build()
@@ -209,6 +208,7 @@ def main(
     ffn_hidden_size,
     num_attention_heads,
     vocab_size,
+    sequence_length,
     micro_batch_size,
     gradient_accumulation,
     recompute_activations,
@@ -228,6 +228,7 @@ def main(
         tensor_model_parallel_size=tensor_parallel_size,
         pipeline_model_parallel_size=pipeline_model_parallel_size,
         virtual_pipeline_model_parallel_size=virtual_pipeline_model_parallel_size,
+        create_gloo_process_groups=False,
     )
 
     model_parallel_cuda_manual_seed(42)
@@ -243,8 +244,8 @@ def main(
             ffn_hidden_size,
             num_attention_heads,
             vocab_size,
-            4096,
-            recompute_activations
+            sequence_length,
+            recompute_activations,
         )
         model = model.to(device)
         model.train()
@@ -262,7 +263,7 @@ def main(
                 ffn_hidden_size,
                 num_attention_heads,
                 vocab_size,
-                4096,
+                sequence_length,
                 recompute_activations
             )
             model_chunk = model_chunk.to(device)
@@ -292,10 +293,10 @@ def main(
     duras_wall = []
     for i in range(iterations):
         if virtual_pipeline_model_parallel_size is None:
-            train_iterator = get_train_data_iterator(vocab_size, micro_batch_size)
+            train_iterator = get_train_data_iterator(vocab_size, micro_batch_size, sequence_length)
         else:
             train_iterator = [
-                get_train_data_iterator(vocab_size, micro_batch_size)
+                get_train_data_iterator(vocab_size, micro_batch_size, sequence_length)
                 for _ in range(virtual_pipeline_model_parallel_size)
             ]
         start, start_wall = time_pair()
@@ -308,7 +309,7 @@ def main(
                 data_iterator=train_iterator,
                 model=model,
                 num_microbatches=num_microbatches,
-                seq_length=4096,
+                seq_length=sequence_length,
                 micro_batch_size=micro_batch_size,
                 forward_only=False,
             )
@@ -318,7 +319,7 @@ def main(
                 data_iterator=train_iterator,
                 model=model,
                 num_microbatches=num_microbatches,
-                seq_length=4096,
+                seq_length=sequence_length,
                 micro_batch_size=micro_batch_size,
                 forward_only=False,
             )
@@ -328,7 +329,7 @@ def main(
                 data_iterator=train_iterator,
                 model=model,
                 num_microbatches=num_microbatches,
-                seq_length=4096,
+                seq_length=sequence_length,
                 micro_batch_size=micro_batch_size,
                 forward_only=False,
             )
@@ -359,6 +360,7 @@ if __name__ == "__main__":
     parser.add_argument("--ffn_hidden_size", type=int, default=11008)
     parser.add_argument("--num_attention_heads", type=int, default=32)
     parser.add_argument("--vocab_size", type=int, default=32000)
+    parser.add_argument("--sequence_length", type=int, default=4096)
     parser.add_argument("--micro_batch_size", type=int, default=1)
     parser.add_argument("--gradient_accumulation", type=int, default=1)
     parser.add_argument("--recompute_activations", action="store_true")
@@ -375,6 +377,7 @@ if __name__ == "__main__":
         ffn_hidden_size=args.ffn_hidden_size,
         num_attention_heads=args.num_attention_heads,
         vocab_size=args.vocab_size,
+        sequence_length=args.sequence_length,
         micro_batch_size=args.micro_batch_size,
         gradient_accumulation=args.gradient_accumulation,
         recompute_activations=args.recompute_activations,

--- a/tests/test_torchtitan.py
+++ b/tests/test_torchtitan.py
@@ -1,6 +1,12 @@
 from phantora_utils import (
-    enable_function_tracer, disable_function_tracer
+    disable_function_tracer,
+    enable_function_tracer,
+    install_phantora_torchtitan_patches,
+    time_pair,
 )
+
+install_phantora_torchtitan_patches()
+
 import torch
 from torchtitan.tools.logging import init_logger
 from torchtitan.config_manager import ConfigManager
@@ -18,15 +24,36 @@ if __name__ == '__main__':
     config = config_manager.parse_args(args)
     trainer = None
 
-    enable_function_tracer()
-
     try:
         trainer = Trainer(config)
+        rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        duras, duras_wall = [], []
+        train_step = trainer.train_step
+
+        def timed_train_step(*args, **kwargs):
+            start, start_wall = time_pair()
+            result = train_step(*args, **kwargs)
+            torch.cuda.synchronize()
+            end, end_wall = time_pair()
+            duras.append(end - start)
+            duras_wall.append(end_wall - start_wall)
+            print(f"rank {rank} iter {len(duras) - 1} time: {end - start:.2f} wall: {end_wall - start_wall:.2f}\n", end="")
+            return result
+
+        trainer.train_step = timed_train_step
+        enable_function_tracer()
         trainer.train()
+        if len(duras) > 1:
+            avg_time = sum(duras[1:]) / (len(duras) - 1)
+            avg_wall = sum(duras_wall[1:]) / (len(duras_wall) - 1)
+        else:
+            avg_time = duras[0] if duras else 0.0
+            avg_wall = duras_wall[0] if duras_wall else 0.0
+        print(f"Rank {rank} Time: {duras} Avg Time: {avg_time:.2f}\n", end="")
+        print(f"Rank {rank} Wall: {duras_wall} Avg Wall: {avg_wall:.2f}\n", end="")
     finally:
+        disable_function_tracer()
         if trainer:
             trainer.close()
         if torch.distributed.is_initialized():
             torch.distributed.destroy_process_group()
-
-    disable_function_tracer()

--- a/tests/test_torchtitan_llama3_8b.toml
+++ b/tests/test_torchtitan_llama3_8b.toml
@@ -31,9 +31,10 @@ dataset = "c4_test"
 
 [parallelism]
 data_parallel_replicate_degree = 1
-data_parallel_shard_degree = -1
+data_parallel_shard_degree = 1
 tensor_parallel_degree = 1
-pipeline_parallel_degree = 1
+pipeline_parallel_degree = 4
+pipeline_parallel_microbatch_size = 1
 context_parallel_degree = 1
 
 [checkpoint]

--- a/tests/test_torchtitan_llama3_8b_pp.toml
+++ b/tests/test_torchtitan_llama3_8b_pp.toml
@@ -31,9 +31,10 @@ dataset = "c4_test"
 
 [parallelism]
 data_parallel_replicate_degree = 1
-data_parallel_shard_degree = -1
+data_parallel_shard_degree = 1
 tensor_parallel_degree = 1
-pipeline_parallel_degree = 1
+pipeline_parallel_degree = 4
+pipeline_parallel_microbatch_size = 1
 context_parallel_degree = 1
 
 [checkpoint]


### PR DESCRIPTION
## Summary

This PR enables pipeline-parallel validation for DeepSpeed and TorchTitan under Phantora, while keeping Phantora's NCCL simulation payload-free. The key change is to keep framework metadata exchange on a real CPU/Gloo process group, so DeepSpeed and TorchTitan can still exchange tensor shape/dtype or object metadata even though activation P2P timing is simulated through Phantora's NCCL path.

## Main changes

### DeepSpeed PP support

- Adds Phantora-specific DeepSpeed patches in `tests/phantora_utils.py`:
  - routes `PipelineEngine._send_tensor_meta` / `_recv_tensor_meta` through a cached CPU/Gloo metadata process group;
  - preserves DeepSpeed's original tensor metadata layout while avoiding simulated GPU payload reads;
  - narrows the BF16 optimizer zero-norm assertion patch to the gradient-clipping path.
- Updates `tests/test_deepspeed.py` to use DeepSpeed's native pipeline path:
  - builds the HF Llama model as a `PipelineModule`;
  - adapts decoder layers for PipelineModule I/O without changing the underlying HF layer implementation;
  - supports PP-only, TP-only, and TP+PP layouts with `PipeModelDataParallelTopology` and `deepspeed.tp_model_init`;
  - uses `train_batch()` so pipeline scheduling follows DeepSpeed's native execution path.

### TorchTitan PP support

- Adds Phantora-specific TorchTitan patches in `tests/phantora_utils.py`:
  - creates the CPU/Gloo metadata group after TorchTitan initializes distributed state;
  - replaces TorchTitan's imported `PipelineStage` with a subclass that keeps `_shape_inference` metadata exchange on the CPU/Gloo group;
  - leaves the actual pipeline activation path on Phantora's NCCL timing simulation.
- Updates `tests/test_torchtitan.py` to install the patch before constructing `Trainer` and to print per-rank Phantora time/wall-time summaries.
- Updates `tests/test_torchtitan_llama3_8b.toml` to exercise pipeline parallelism by default with `pipeline_parallel_degree = 4`.

### Supporting cleanup

- Fixes estimator tensor-cache layout handling in `phantora/phantora/src/torch_estimate.rs` so cached tensors are contiguous before reuse and linear timing uses the expected dtype.
- Makes Megatron validation sequence length configurable instead of hardcoding `4096` in every call path.
- Updates the README support matrix to mark DeepSpeed and TorchTitan PP as supported, with the remaining limitation documented as payload-inspecting paths needing CPU backend handling.

## Why this is needed

Phantora models NCCL timing and ordering, including point-to-point send/recv, but it does not transfer tensor payload bytes between ranks. DeepSpeed and TorchTitan both perform metadata exchange during pipeline setup/execution before the activation transfer itself:

- DeepSpeed sends tensor metadata from `PipelineEngine` to describe activation buffers.
- TorchTitan sends object metadata during `PipelineStage._shape_inference`.

If that metadata goes through simulated GPU/NCCL payloads, the receiving rank can see invalid shape/dtype/object information. Routing only metadata through CPU/Gloo keeps framework control flow correct while preserving Phantora's simulated NCCL path for pipeline communication timing.


