### PR TITLE
tests: per-model preset scripts per framework

### DIFF
--- a/tests/docker/deepspeed/llama/run_llama2_13b.sh
+++ b/tests/docker/deepspeed/llama/run_llama2_13b.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Phantora preset: Llama2 13B (ZeRO-3 via DeepSpeed).
+
+WORKDIR=$(dirname "$(realpath "$0")")
+
+MODEL_ARGS=(
+    --num_layers 40
+    --hidden_size 5120
+    --ffn_hidden_size 13824
+    --num_attention_heads 40
+    --vocab_size 32000
+    --rope_theta 10000
+)
+
+exec "$WORKDIR/../run.sh" \
+    "${MODEL_ARGS[@]}" \
+    "$@"

--- a/tests/docker/deepspeed/llama/run_llama2_70b.sh
+++ b/tests/docker/deepspeed/llama/run_llama2_70b.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Phantora preset: Llama2 70B (ZeRO-3 via DeepSpeed).
+#
+# Note: 70B uses GQA (8 KV groups / 64 Q heads).
+
+WORKDIR=$(dirname "$(realpath "$0")")
+
+MODEL_ARGS=(
+    --num_layers 80
+    --hidden_size 8192
+    --ffn_hidden_size 28672
+    --num_attention_heads 64
+    --num_key_value_heads 8
+    --vocab_size 32000
+    --rope_theta 10000
+)
+
+exec "$WORKDIR/../run.sh" \
+    "${MODEL_ARGS[@]}" \
+    "$@"

--- a/tests/docker/deepspeed/llama/run_llama2_7b.sh
+++ b/tests/docker/deepspeed/llama/run_llama2_7b.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Phantora preset: Llama2 7B (ZeRO-3 via DeepSpeed).
+
+WORKDIR=$(dirname "$(realpath "$0")")
+
+MODEL_ARGS=(
+    --num_layers 32
+    --hidden_size 4096
+    --ffn_hidden_size 11008
+    --num_attention_heads 32
+    --vocab_size 32000
+    --rope_theta 10000
+)
+
+exec "$WORKDIR/../run.sh" \
+    "${MODEL_ARGS[@]}" \
+    "$@"

--- a/tests/docker/deepspeed/llama/run_llama3_70b.sh
+++ b/tests/docker/deepspeed/llama/run_llama3_70b.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Phantora preset: Llama3 70B (ZeRO-3 via DeepSpeed).
+
+WORKDIR=$(dirname "$(realpath "$0")")
+
+MODEL_ARGS=(
+    --num_layers 80
+    --hidden_size 8192
+    --ffn_hidden_size 28672
+    --num_attention_heads 64
+    --num_key_value_heads 8
+    --vocab_size 128256
+    --rope_theta 500000
+)
+
+exec "$WORKDIR/../run.sh" \
+    "${MODEL_ARGS[@]}" \
+    "$@"

--- a/tests/docker/deepspeed/llama/run_llama3_8b.sh
+++ b/tests/docker/deepspeed/llama/run_llama3_8b.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Phantora preset: Llama3 8B (ZeRO-3 via DeepSpeed).
+#
+# Differences from Llama2: GQA across all sizes, larger vocab (128K),
+# and a much larger RoPE base (500K).
+
+WORKDIR=$(dirname "$(realpath "$0")")
+
+MODEL_ARGS=(
+    --num_layers 32
+    --hidden_size 4096
+    --ffn_hidden_size 14336
+    --num_attention_heads 32
+    --num_key_value_heads 8
+    --vocab_size 128256
+    --rope_theta 500000
+)
+
+exec "$WORKDIR/../run.sh" \
+    "${MODEL_ARGS[@]}" \
+    "$@"

--- a/tests/docker/megatron/llama/run_llama2_13b.sh
+++ b/tests/docker/megatron/llama/run_llama2_13b.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Phantora preset: Llama2 13B.
+
+WORKDIR=$(dirname "$(realpath "$0")")
+
+MODEL_ARGS=(
+    --num_layers 40
+    --hidden_size 5120
+    --ffn_hidden_size 13824
+    --num_attention_heads 40
+    --vocab_size 32000
+    --swiglu
+    --position_embedding_type rope
+    --rotary_base 10000
+    --normalization RMSNorm
+    --disable_bias_linear
+)
+
+exec "$WORKDIR/../run.sh" \
+    "${MODEL_ARGS[@]}" \
+    "$@"

--- a/tests/docker/megatron/llama/run_llama2_70b.sh
+++ b/tests/docker/megatron/llama/run_llama2_70b.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Phantora preset: Llama2 70B.
+#
+# Note: 70B uses GQA (8 KV groups / 64 Q heads), unlike the 7B/13B variants.
+
+WORKDIR=$(dirname "$(realpath "$0")")
+
+MODEL_ARGS=(
+    --num_layers 80
+    --hidden_size 8192
+    --ffn_hidden_size 28672
+    --num_attention_heads 64
+    --num_query_groups 8
+    --vocab_size 32000
+    --swiglu
+    --position_embedding_type rope
+    --rotary_base 10000
+    --normalization RMSNorm
+    --disable_bias_linear
+)
+
+exec "$WORKDIR/../run.sh" \
+    "${MODEL_ARGS[@]}" \
+    "$@"

--- a/tests/docker/megatron/llama/run_llama2_7b.sh
+++ b/tests/docker/megatron/llama/run_llama2_7b.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Phantora preset: Llama2 7B.
+#
+# Mirrors upstream Megatron-LM's examples/llama/ shell scripts. Numbers are
+# the published Llama2 7B config; extra args are forwarded to ../run.sh.
+
+WORKDIR=$(dirname "$(realpath "$0")")
+
+MODEL_ARGS=(
+    --num_layers 32
+    --hidden_size 4096
+    --ffn_hidden_size 11008
+    --num_attention_heads 32
+    --vocab_size 32000
+    --swiglu
+    --position_embedding_type rope
+    --rotary_base 10000
+    --normalization RMSNorm
+    --disable_bias_linear
+)
+
+exec "$WORKDIR/../run.sh" \
+    "${MODEL_ARGS[@]}" \
+    "$@"

--- a/tests/docker/megatron/llama/run_llama3_70b.sh
+++ b/tests/docker/megatron/llama/run_llama3_70b.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Phantora preset: Llama3 70B.
+
+WORKDIR=$(dirname "$(realpath "$0")")
+
+MODEL_ARGS=(
+    --num_layers 80
+    --hidden_size 8192
+    --ffn_hidden_size 28672
+    --num_attention_heads 64
+    --num_query_groups 8
+    --vocab_size 128256
+    --swiglu
+    --position_embedding_type rope
+    --rotary_base 500000
+    --normalization RMSNorm
+    --disable_bias_linear
+)
+
+exec "$WORKDIR/../run.sh" \
+    "${MODEL_ARGS[@]}" \
+    "$@"

--- a/tests/docker/megatron/llama/run_llama3_8b.sh
+++ b/tests/docker/megatron/llama/run_llama3_8b.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Phantora preset: Llama3 8B.
+#
+# Differences from Llama2: GQA across all sizes, larger vocab (128K),
+# and a much larger RoPE base (500K).
+
+WORKDIR=$(dirname "$(realpath "$0")")
+
+MODEL_ARGS=(
+    --num_layers 32
+    --hidden_size 4096
+    --ffn_hidden_size 14336
+    --num_attention_heads 32
+    --num_query_groups 8
+    --vocab_size 128256
+    --swiglu
+    --position_embedding_type rope
+    --rotary_base 500000
+    --normalization RMSNorm
+    --disable_bias_linear
+)
+
+exec "$WORKDIR/../run.sh" \
+    "${MODEL_ARGS[@]}" \
+    "$@"

--- a/tests/docker/torchtitan/llama3/run_llama3_8b.sh
+++ b/tests/docker/torchtitan/llama3/run_llama3_8b.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Phantora preset: Llama3 8B (TorchTitan + FSDP2).
+#
+# TorchTitan reads its config from a .toml file; this script points run.sh at
+# the canonical Llama3 8B config that ships with Phantora. Extra args are
+# forwarded — useful for TorchTitan-style overrides like
+# `--parallelism.tensor_parallel_degree=2`.
+
+WORKDIR=$(dirname "$(realpath "$0")")
+
+exec "$WORKDIR/../run.sh" \
+    --job.config_file=/phantora/tests/test_torchtitan_llama3_8b.toml \
+    "$@"

--- a/tests/test_deepspeed.py
+++ b/tests/test_deepspeed.py
@@ -52,7 +52,9 @@ def build_pipeline_model(args: argparse.Namespace) -> PipelineModule:
         intermediate_size=args.ffn_hidden_size,
         num_hidden_layers=args.num_layers,
         num_attention_heads=args.num_attention_heads,
+        num_key_value_heads=args.num_key_value_heads,
         max_position_embeddings=args.sequence_length,
+        rope_theta=args.rope_theta,
         use_cache=False,
         attn_implementation="flash_attention_2",
     )
@@ -168,7 +170,10 @@ if __name__ == "__main__":
     parser.add_argument("--hidden_size", type=int, default=4096)
     parser.add_argument("--ffn_hidden_size", type=int, default=11008)
     parser.add_argument("--num_attention_heads", type=int, default=32)
+    parser.add_argument("--num_key_value_heads", type=int, default=None,
+        help="Number of KV heads for GQA (None = MHA, i.e., equal to num_attention_heads).")
     parser.add_argument("--vocab_size", type=int, default=32000)
+    parser.add_argument("--rope_theta", type=float, default=10000.0)
     parser.add_argument("--sequence_length", type=int, default=4096)
     parser.add_argument("--micro_batch_size", type=int, default=1)
     parser.add_argument("--gradient_accumulation", type=int, default=1)

--- a/tests/test_megatron.py
+++ b/tests/test_megatron.py
@@ -94,9 +94,15 @@ def get_model(
     hidden_size,
     ffn_hidden_size,
     num_attention_heads,
+    num_query_groups,
     vocab_size,
     sequence_length,
     recompute_activations,
+    swiglu,
+    position_embedding_type,
+    rotary_base,
+    normalization,
+    disable_bias_linear,
 ):
     transformer_config = TransformerConfig(
         tensor_model_parallel_size=tensor_parallel_size,
@@ -106,6 +112,11 @@ def get_model(
         hidden_size=hidden_size,
         ffn_hidden_size=ffn_hidden_size,
         num_attention_heads=num_attention_heads,
+        num_query_groups=num_query_groups,
+        gated_linear_unit=swiglu,
+        activation_func=torch.nn.functional.silu if swiglu else torch.nn.functional.gelu,
+        normalization=normalization,
+        add_bias_linear=not disable_bias_linear,
         perform_initialization=False,
         bf16=True,
         params_dtype=torch.bfloat16,
@@ -121,6 +132,8 @@ def get_model(
             transformer_layer_spec=get_gpt_layer_local_spec(),
             vocab_size=vocab_size,
             max_sequence_length=sequence_length,
+            position_embedding_type=position_embedding_type,
+            rotary_base=rotary_base,
             pre_process=parallel_state.is_pipeline_first_stage(
                 ignore_virtual=False, vp_stage=vp_stage
             ),
@@ -207,12 +220,18 @@ def main(
     hidden_size,
     ffn_hidden_size,
     num_attention_heads,
+    num_query_groups,
     vocab_size,
     sequence_length,
     micro_batch_size,
     gradient_accumulation,
     recompute_activations,
     iterations,
+    swiglu,
+    position_embedding_type,
+    rotary_base,
+    normalization,
+    disable_bias_linear,
 ):
     world_size = int(os.environ["WORLD_SIZE"])
     rank = int(os.environ["RANK"])
@@ -243,9 +262,15 @@ def main(
             hidden_size,
             ffn_hidden_size,
             num_attention_heads,
+            num_query_groups,
             vocab_size,
             sequence_length,
             recompute_activations,
+            swiglu,
+            position_embedding_type,
+            rotary_base,
+            normalization,
+            disable_bias_linear,
         )
         model = model.to(device)
         model.train()
@@ -262,9 +287,15 @@ def main(
                 hidden_size,
                 ffn_hidden_size,
                 num_attention_heads,
+                num_query_groups,
                 vocab_size,
                 sequence_length,
-                recompute_activations
+                recompute_activations,
+                swiglu,
+                position_embedding_type,
+                rotary_base,
+                normalization,
+                disable_bias_linear,
             )
             model_chunk = model_chunk.to(device)
             model_chunk.train()
@@ -359,12 +390,24 @@ if __name__ == "__main__":
     parser.add_argument("--hidden_size", type=int, default=4096)
     parser.add_argument("--ffn_hidden_size", type=int, default=11008)
     parser.add_argument("--num_attention_heads", type=int, default=32)
+    parser.add_argument("--num_query_groups", type=int, default=None,
+        help="Number of KV heads for GQA (None = MHA, i.e., equal to num_attention_heads).")
     parser.add_argument("--vocab_size", type=int, default=32000)
     parser.add_argument("--sequence_length", type=int, default=4096)
     parser.add_argument("--micro_batch_size", type=int, default=1)
     parser.add_argument("--gradient_accumulation", type=int, default=1)
     parser.add_argument("--recompute_activations", action="store_true")
     parser.add_argument("--iterations", type=int, default=4)
+    # Architectural knobs (names mirror Megatron's TransformerConfig / GPTModel fields).
+    parser.add_argument("--swiglu", action="store_true",
+        help="Use SwiGLU gated MLP (Megatron's `gated_linear_unit=True`).")
+    parser.add_argument("--position_embedding_type", type=str, default="learned_absolute",
+        choices=["learned_absolute", "rope"])
+    parser.add_argument("--rotary_base", type=float, default=10000.0)
+    parser.add_argument("--normalization", type=str, default="LayerNorm",
+        choices=["LayerNorm", "RMSNorm"])
+    parser.add_argument("--disable_bias_linear", action="store_true",
+        help="Set `add_bias_linear=False` (Megatron default is True).")
     args = parser.parse_args()
 
     enable_function_tracer()
@@ -382,5 +425,11 @@ if __name__ == "__main__":
         gradient_accumulation=args.gradient_accumulation,
         recompute_activations=args.recompute_activations,
         iterations=args.iterations,
+        num_query_groups=args.num_query_groups,
+        swiglu=args.swiglu,
+        position_embedding_type=args.position_embedding_type,
+        rotary_base=args.rotary_base,
+        normalization=args.normalization,
+        disable_bias_linear=args.disable_bias_linear,
     )
     disable_function_tracer()


### PR DESCRIPTION
Add a per-(model, size) shell script layout under tests/docker/<framework>/<family>/, mirroring upstream Megatron's examples/<family>/ tree (examples/llama/train_llama2_7b_distributed.sh etc.). Each script builds a small bash array of model args and execs the framework's generic run.sh; the generic runner keeps owning docker compose orchestration and torchrun launch.

Adds 11 Llama presets (7B/13B/70B Llama2 + 8B/70B Llama3) across Megatron and DeepSpeed, plus Llama3 8B for TorchTitan (which already had its TOML).

Megatron (test_megatron.py): expose architectural knobs as CLI flags whose names mirror TransformerConfig fields directly:
  --num_query_groups, --swiglu, --position_embedding_type, --rotary_base,
  --normalization, --disable_bias_linear
This lets each per-model script select GQA / SwiGLU / RoPE / RMSNorm / no-bias without bundling them behind a Phantora-invented preset boolean.

DeepSpeed (test_deepspeed.py): expose --num_key_value_heads and --rope_theta so Llama2-70B and Llama3 (which use GQA + extended RoPE base) can be expressed.