### PR TITLE
Fix sequence-length-dependent estimation gap: charge SDPA with materialized masks, and pump parked sync replies

### DIFF
--- a/phantora/Cargo.lock
+++ b/phantora/Cargo.lock
@@ -807,6 +807,7 @@ name = "phantora"
 version = "0.0.1"
 dependencies = [
  "bincode",
+ "cc",
  "clap",
  "cuda_call",
  "env_logger",
@@ -1207,8 +1208,8 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tch"
-version = "0.20.0"
-source = "git+https://github.com/QDelta/tch-rs?branch=fix-0.20.0#c71bac49e98e06c5427f4ea8ddcf6fda704e1e30"
+version = "0.22.0"
+source = "git+https://github.com/QDelta/tch-rs?rev=f7fb153bd46c0df5f1107f3748b5595d6c39a1dc#f7fb153bd46c0df5f1107f3748b5595d6c39a1dc"
 dependencies = [
  "half",
  "lazy_static",
@@ -1305,8 +1306,8 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "torch-sys"
-version = "0.20.0"
-source = "git+https://github.com/QDelta/tch-rs?branch=fix-0.20.0#c71bac49e98e06c5427f4ea8ddcf6fda704e1e30"
+version = "0.22.0"
+source = "git+https://github.com/QDelta/tch-rs?rev=f7fb153bd46c0df5f1107f3748b5595d6c39a1dc#f7fb153bd46c0df5f1107f3748b5595d6c39a1dc"
 dependencies = [
  "anyhow",
  "cc",

--- a/phantora/phantora/src/main.rs
+++ b/phantora/phantora/src/main.rs
@@ -106,5 +106,6 @@ fn main_loop() {
                 simulator.handle_exit(host, cur);
             }
         }
+        simulator.pump_parked_syncs();
     }
 }

--- a/phantora/phantora/src/simulator.rs
+++ b/phantora/phantora/src/simulator.rs
@@ -420,6 +420,25 @@ impl Simulator {
         }
     }
 
+    /// Run the event queue to exhaustion and deliver any parked sync replies
+    /// whose events have completed. No-op when no reply is parked.
+    pub fn pump_parked_syncs(&mut self) {
+        if self.syncing.is_empty() {
+            return;
+        }
+        loop {
+            match self.queue.execute() {
+                QueueStep::EmptyQueue => return,
+                QueueStep::EventStarted(..) => (),
+                QueueStep::EventEnded(id, time) | QueueStep::ReachedPoint(id, time) => {
+                    if let Some(host) = self.syncing.remove(&id) {
+                        send_sync_response_to(&mut self.host_times, host, time, Some(id));
+                    }
+                }
+            }
+        }
+    }
+
     fn execute_to_time(
         queue: &mut EventQueue,
         syncing: &mut HashMap<EventId, ResponseId>,

--- a/phantora/phantora/src/torch_call.rs
+++ b/phantora/phantora/src/torch_call.rs
@@ -776,7 +776,8 @@ impl TorchCallMsg {
                 }
             },
             "aten::scaled_dot_product_attention" => match self.args.as_slice() {
-                [Tensor(shape1, kind1, _), Tensor(shape2, kind2, _), Tensor(shape3, kind3, _), _, Bool(causal), Bool(gqa)] => {
+                [Tensor(shape1, kind1, _), Tensor(shape2, kind2, _), Tensor(shape3, kind3, _), Tensor(mask_shape, mask_kind, _), Double(_), Bool(causal), Double(_), Bool(gqa)]
+                | [Tensor(shape1, kind1, _), Tensor(shape2, kind2, _), Tensor(shape3, kind3, _), Tensor(mask_shape, mask_kind, _), Double(_), Bool(causal), Bool(gqa)] => {
                     Some(TorchCallInfo::SDPA {
                         q: TensorInfo {
                             shape: shape1.clone(),
@@ -790,6 +791,30 @@ impl TorchCallMsg {
                             shape: shape3.clone(),
                             dtype: *kind3,
                         },
+                        mask: Some(TensorInfo {
+                            shape: mask_shape.clone(),
+                            dtype: *mask_kind,
+                        }),
+                        causal: *causal,
+                        gqa: *gqa,
+                    })
+                }
+                [Tensor(shape1, kind1, _), Tensor(shape2, kind2, _), Tensor(shape3, kind3, _), Double(_), Bool(causal), Double(_), Bool(gqa)]
+                | [Tensor(shape1, kind1, _), Tensor(shape2, kind2, _), Tensor(shape3, kind3, _), Double(_), Bool(causal), Bool(gqa)] => {
+                    Some(TorchCallInfo::SDPA {
+                        q: TensorInfo {
+                            shape: shape1.clone(),
+                            dtype: *kind1,
+                        },
+                        k: TensorInfo {
+                            shape: shape2.clone(),
+                            dtype: *kind2,
+                        },
+                        v: TensorInfo {
+                            shape: shape3.clone(),
+                            dtype: *kind3,
+                        },
+                        mask: None,
                         causal: *causal,
                         gqa: *gqa,
                     })
@@ -828,6 +853,54 @@ impl TorchCallMsg {
                         },
                         max_q: *max_q,
                         max_k: *max_k,
+                        causal: *causal,
+                    })
+                }
+                _ => {
+                    log::warn!("{} args not match: {:?}", self.name, self.args);
+                    None
+                }
+            },
+            "aten::_scaled_dot_product_efficient_attention_backward" => match self.args.as_slice() {
+                [Tensor(_, _, _), Tensor(shape2, kind2, _), Tensor(shape3, kind3, _), Tensor(shape4, kind4, _), bias_arg, Tensor(_, _, _), Tensor(_, _, _), _, _, Double(_), List(_), Bool(causal), ..] => {
+                    Some(TorchCallInfo::SDPAEfficientBackward {
+                        q: TensorInfo {
+                            shape: shape2.clone(),
+                            dtype: *kind2,
+                        },
+                        k: TensorInfo {
+                            shape: shape3.clone(),
+                            dtype: *kind3,
+                        },
+                        v: TensorInfo {
+                            shape: shape4.clone(),
+                            dtype: *kind4,
+                        },
+                        bias: match bias_arg {
+                            Tensor(bias_shape, bias_kind, _) => Some(TensorInfo {
+                                shape: bias_shape.clone(),
+                                dtype: *bias_kind,
+                            }),
+                            _ => None,
+                        },
+                        causal: *causal,
+                    })
+                }
+                [Tensor(_, _, _), Tensor(shape2, kind2, _), Tensor(shape3, kind3, _), Tensor(shape4, kind4, _), Tensor(_, _, _), Tensor(_, _, _), _, _, Double(_), List(_), Bool(causal), ..] => {
+                    Some(TorchCallInfo::SDPAEfficientBackward {
+                        q: TensorInfo {
+                            shape: shape2.clone(),
+                            dtype: *kind2,
+                        },
+                        k: TensorInfo {
+                            shape: shape3.clone(),
+                            dtype: *kind3,
+                        },
+                        v: TensorInfo {
+                            shape: shape4.clone(),
+                            dtype: *kind4,
+                        },
+                        bias: None,
                         causal: *causal,
                     })
                 }
@@ -991,8 +1064,16 @@ pub enum TorchCallInfo {
         q: TensorInfo,
         k: TensorInfo,
         v: TensorInfo,
+        mask: Option<TensorInfo>,
         causal: bool,
         gqa: bool,
+    },
+    SDPAEfficientBackward {
+        q: TensorInfo,
+        k: TensorInfo,
+        v: TensorInfo,
+        bias: Option<TensorInfo>,
+        causal: bool,
     },
     SDPABackward {
         grad: TensorInfo,

--- a/phantora/phantora/src/torch_estimate.rs
+++ b/phantora/phantora/src/torch_estimate.rs
@@ -381,19 +381,21 @@ impl TorchEstimator {
                 q,
                 k,
                 v,
+                mask,
                 causal,
                 gqa,
             } => {
                 let t_q = self.allocate(q);
                 let t_k = self.allocate(k);
                 let t_v = self.allocate(v);
+                let t_mask = mask.as_ref().map(|info| self.allocate(info));
                 let (result, dur) = estimate_torch!(
                     niter,
                     Tensor::f_scaled_dot_product_attention(
                         &t_q,
                         &t_k,
                         &t_v,
-                        None::<Tensor>,
+                        t_mask.as_ref(),
                         0.0,
                         *causal,
                         None,
@@ -402,6 +404,35 @@ impl TorchEstimator {
                     .unwrap()
                 );
                 self.cache(result);
+                dur
+            }
+            TorchCallInfo::SDPAEfficientBackward {
+                q,
+                k,
+                v,
+                bias,
+                causal,
+            } => {
+                // Build the forward graph via autograd, then time only the backward.
+                let t_q = self.allocate(q).detach().set_requires_grad(true);
+                let t_k = self.allocate(k).detach().set_requires_grad(true);
+                let t_v = self.allocate(v).detach().set_requires_grad(true);
+                let t_bias = bias.as_ref().map(|info| self.allocate(info));
+                let out = Tensor::scaled_dot_product_attention(
+                    &t_q,
+                    &t_k,
+                    &t_v,
+                    t_bias.as_ref(),
+                    0.0,
+                    *causal,
+                    None,
+                    false,
+                )
+                .sum(Kind::Float);
+                let (_, dur) = estimate_torch!(
+                    niter,
+                    Tensor::run_backward(&[&out], &[&t_q, &t_k, &t_v], true, false)
+                );
                 dur
             }
             TorchCallInfo::SDPABackward {


### PR DESCRIPTION
1. **`fix(catalog)`: charge SDPA with materialized masks and the mem-efficient attention backward.**
   The `aten::scaled_dot_product_attention` catalog arm only matched the layout where `attn_mask` and `scale` are omitted (the flag-style causal call). Workloads that pass a materialized mask (e.g. HF transformers) never matched, and their backward op `aten::_scaled_dot_product_efficient_attention_backward` had no arm at all — so the entire attention computation was charged **zero**. Attention is the only O(seq²) cost in a transformer step, so the estimation error grew with sequence length.
   The forward arm now matches all mask/scale layouts and carries the mask shape, so the estimator reproduces the workload's kernel dispatch (a materialized mask forces the mem-efficient backend) and its mask traffic. The backward is timed by replaying the same composite forward via autograd and measuring only `Tensor::run_backward` (the direct tch binding for the mem-efficient backward does not exist).

2. **`fix(simulator)`: pump parked sync replies after each message.**
   A parked sync reply could starve when all ranks were blocked at once, since the event queue was only re-run from sync/query handlers. This made `PHANTORA_IGNORE_CPU_TIME=1` runs ~10× slower in wall-clock (progress only resumed when an unrelated periodic message arrived). The queue is now run to exhaustion after every handled message; simulated results are unchanged.

3. **`build`: regenerate `Cargo.lock`** — the committed lock still recorded tch 0.20.0 while `Cargo.toml` pins rev `f7fb153` (0.22.0) and adds the `cc` build-dep; any cargo invocation regenerates this deterministically.